### PR TITLE
Verify username using ad

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The main credentialing application that automates the full student laptop setup 
 1. Verifies BIOS lockdown status
 2. Confirms administrative privileges
 3. Caches configuration data in registry
-4. Pulls SMC configuration and validates student account
+4. Validates student account (optionally fetches Canvas tokens from SMC when configured)
 5. Syncs network interface and time settings
 6. Orchestrates `mgmt.exe` commands to:
    - Unlock the machine
@@ -155,7 +155,7 @@ A utility for capturing screenshots of the student's desktop for monitoring purp
 
 3. **Configure credential application:**
    - Edit `credential/credential_config.json`
-   - Set SMC URL, admin username, and other required settings
+   - Set required settings (optionally set `smc_url` and `smc_admin_username` for Canvas token integration)
    - See [credential/README.md](credential/README.md) for configuration details
 
 4. **Run credentialing process:**
@@ -313,7 +313,7 @@ Where level is typically 1-5 (higher = more verbose).
 ### Credentialing Fails
 - Verify BIOS is locked down (set `have_you_locked_down_the_bios: true`)
 - Ensure running as Administrator
-- Check SMC connectivity and credentials
+- If SMC is configured, check SMC connectivity and credentials
 - Review `ope-credential.log` for detailed error messages
 
 ### Network Issues

--- a/RELEASE_LOG.md
+++ b/RELEASE_LOG.md
@@ -1,5 +1,20 @@
 # Release Log
 
+## 26.4.1
+### credential script:
+- Replaced SMC server dependency with local Active Directory (ADSI) verification for student accounts
+- Removed need for SMC URL, SMC admin username, and SMC admin password configuration
+- Added `is_domain_joined` and `base_dn` as new required configuration keys in `credential_config.json`
+- Student accounts on domain-joined laptops are now validated directly against Active Directory
+- Auto-generates secure passwords for students on non-domain-joined (standalone) laptops
+- Fixed crash when `approved_nics` registry value is empty or contains invalid JSON
+- Improved debug mode: skips OPEService startup check when debug is enabled
+### mgmt modules:
+- Replaced `laptop_network_type` / `laptop_domain_name` with a single `is_domain_joined` flag throughout
+- Removed `store_smc_config`, `trust_ope_certs`, and SMC-related registry operations
+- Simplified interactive configuration by removing all SMC-related prompts
+- Domain name is now read from the machine's computer system info instead of stored registry values
+
 ## 25.11.3
 ### credential script:
 - New automated credentialing workflow (`credential.exe`) instead of (`credential.cmd`) with config file input instead of CLI prompting

--- a/common/color.py
+++ b/common/color.py
@@ -1,12 +1,6 @@
 import os
 import psutil
-#import logging
-# Resolve the same EventLog class as mgmt.py (flat mgmt_EventLog vs package mgmt.mgmt_EventLog) so
-# get_current_instance() sees the singleton mgmt/credential/OPEService already created.
-try:
-    from mgmt_EventLog import EventLog
-except ImportError:
-    from mgmt.mgmt_EventLog import EventLog
+from mgmt.mgmt_EventLog import EventLog
 
 global LOGGER
 LOGGER = None  # Filled from EventLog.get_current_instance() on first p(); stays None if no app logger exists

--- a/common/color.py
+++ b/common/color.py
@@ -1,11 +1,15 @@
 import os
-import common.util
 import psutil
 #import logging
-from mgmt.mgmt_EventLog import EventLog
+# Resolve the same EventLog class as mgmt.py (flat mgmt_EventLog vs package mgmt.mgmt_EventLog) so
+# get_current_instance() sees the singleton mgmt/credential/OPEService already created.
+try:
+    from mgmt_EventLog import EventLog
+except ImportError:
+    from mgmt.mgmt_EventLog import EventLog
 
 global LOGGER
-LOGGER = None  # Grab it later - give it a chance to get initialized
+LOGGER = None  # Filled from EventLog.get_current_instance() on first p(); stays None if no app logger exists
 
 import re
 import sys
@@ -26,16 +30,10 @@ def get_log_level():
     return LOG_LEVEL
 
 def init_logger():
+    """Attach to the app's EventLog singleton if one exists; no logger is created here."""
     global LOGGER
     if LOGGER is None:
         LOGGER = EventLog.get_current_instance()
-        if LOGGER is None:
-            # Make default logger
-            LOGGER = EventLog(os.path.join(common.util.LOG_FOLDER, 'ope-mgmt.log'), service_name="OPE")
-        # if LOGGER is None:
-        #     print("Unable to get logger instance!")
-        # else:
-        #     print("Logger: " + str(LOGGER.log_file))
 
 
 CSI = "\x1b["

--- a/common/util.py
+++ b/common/util.py
@@ -145,12 +145,12 @@ def check_adsi(username, base_dn):
         cmd.ActiveConnection = conn
         cmd.CommandText = f"SELECT distinguishedName FROM '{ad_path}' WHERE objectCategory='user' AND sAMAccountName='{safe_user}'"
 
-        rs = cmd.Execute()
-        if rs.EOS:
-            return False, None
+        rs = cmd.Execute()[0]
+        if rs.EOF or rs is None:
+            return False, "User not found in Active Directory"
         return True, None
     except Exception as e:
-        return False, str(e)
+        return False, "Error checking Active Directory: " + str(e)
 
 def verify_student_account_in_ad(username, base_dn):
     """Verify student account in Active Directory

--- a/common/util.py
+++ b/common/util.py
@@ -143,12 +143,12 @@ def check_adsi(username, base_dn):
 
         cmd = win32com.client.Dispatch("ADODB.Command")
         cmd.ActiveConnection = conn
-        cmd.CommandText = f"SELECT distinguishedName FROM '{ad_path}' WHERE objectCategory='user' AND sAMAccountName='{safe_user}'"
+        cmd.CommandText = f"SELECT displayName FROM '{ad_path}' WHERE objectCategory='user' AND sAMAccountName='{safe_user}'"
 
         rs = cmd.Execute()[0]
         if rs.EOF or rs is None:
             return False, "User not found in Active Directory"
-        return True, None
+        return True, rs.Fields("displayName").Value
     except Exception as e:
         return False, "Error checking Active Directory: " + str(e)
 

--- a/common/util.py
+++ b/common/util.py
@@ -2,6 +2,7 @@ import sys
 import os
 from win32com.shell import shellcon, shell
 import win32cred
+import win32com.client
 
 # Should be programdata files folder
 ROOT_FOLDER = os.path.join(
@@ -95,12 +96,12 @@ def get_param(param_index=1, default_value="", only_for=None):
     
     return ret
 
-def store_smc_password(username, password):
-    """Store the SMC password in the credential vault"""
+def store_password(username, password):
+    """Store password in the credential vault"""
     from common.color import p
     
     credential_data = {
-        "TargetName": f"SMC_{username}",
+        "TargetName": f"{username}",
         "Type": win32cred.CRED_TYPE_GENERIC,
         "UserName": username,
         "CredentialBlob": password,
@@ -109,22 +110,66 @@ def store_smc_password(username, password):
 
     try:
         win32cred.CredWrite(credential_data, 0)
-        p("}}gnSMC admin password stored in the credential vault successfully}}xx", log_level=3)
+        p("}}gnPassword stored in the credential vault successfully}}xx", log_level=3)
         return True
     except Exception as ex:
-        p("}}rbERROR: Failed to store SMC admin password in the credential vault: " + str(ex) + "}}xx", log_level=1)
+        p("}}rbERROR: Failed to store password in the credential vault: " + str(ex) + "}}xx", log_level=1)
         return False
 
-def get_smc_password(username):
-    """Get the SMC password from the credential vault"""
+def get_password(username):
+    """Get password from the credential vault"""
     from common.color import p
     
     try:
-        credential_data = win32cred.CredRead(f"SMC_{username}", win32cred.CRED_TYPE_GENERIC)
+        credential_data = win32cred.CredRead(f"{username}", win32cred.CRED_TYPE_GENERIC)
         return credential_data["CredentialBlob"].decode('utf-16le')
     except Exception as ex:
-        p("}}ynNo password found for SMC_" + username + " in the credential vault " + str(ex) + "}}xx", log_level=1)
+        p("}}ynNo password found for " + username + " in the credential vault " + str(ex) + "}}xx", log_level=1)
         return None
+
+
+def check_adsi(username, base_dn):
+    """Validate username using Windows ADSI (Active Directory Service Interfaces, via pywin32). Only works on Windows, domain-joined."""
+
+    try:
+        # LDAP path to the OU we care about (ADSI ADO uses this in FROM clause)
+        ad_path = f"LDAP://{base_dn}"
+        # Escape special chars in username for LDAP filter
+        safe_user = username.replace("\\", "\\5c").replace("*", "\\2a").replace("(", "\\28").replace(")", "\\29")
+
+        conn = win32com.client.Dispatch("ADODB.Connection")
+        conn.Provider = "ADsDSOObject"
+        conn.Open("Active Directory Provider", "", "")
+
+        cmd = win32com.client.Dispatch("ADODB.Command")
+        cmd.ActiveConnection = conn
+        cmd.CommandText = f"SELECT distinguishedName FROM '{ad_path}' WHERE objectCategory='user' AND sAMAccountName='{safe_user}'"
+
+        rs = cmd.Execute()
+        if rs.EOS:
+            return False, None
+        return True, None
+    except Exception as e:
+        return False, str(e)
+
+def verify_student_account_in_ad(username, base_dn):
+    """Verify student account in Active Directory
+        Run only on a domain-joined Windows machine.
+
+    Args:
+        username: The sAMAccountName (logon name) to look up.
+        base_dn: LDAP base DN (e.g. "OU=ABC Corp Users, DC=abc, DC=org).
+        """
+    if not username or not username.strip():
+        return False, "Username is empty"
+
+    username = username.strip()
+    base_dn = base_dn
+
+    if sys.platform != "win32":
+        return False, "Requires Windows on a domain-joined machine (ADSI)."
+
+    return check_adsi(username, base_dn)
 
 def test_params():
 

--- a/common/util.py
+++ b/common/util.py
@@ -96,12 +96,12 @@ def get_param(param_index=1, default_value="", only_for=None):
     
     return ret
 
-def store_password(username, password):
-    """Store password in the credential vault"""
+def store_smc_password(username, password):
+    """Store SMC admin password in the credential vault"""
     from common.color import p
     
     credential_data = {
-        "TargetName": f"{username}",
+        "TargetName": f"SMC_{username}",
         "Type": win32cred.CRED_TYPE_GENERIC,
         "UserName": username,
         "CredentialBlob": password,
@@ -110,21 +110,21 @@ def store_password(username, password):
 
     try:
         win32cred.CredWrite(credential_data, 0)
-        p("}}gnPassword stored in the credential vault successfully}}xx", log_level=3)
+        p("}}gnSMC admin password stored in the credential vault successfully}}xx", log_level=3)
         return True
     except Exception as ex:
-        p("}}rbERROR: Failed to store password in the credential vault: " + str(ex) + "}}xx", log_level=1)
+        p("}}rbERROR: Failed to store SMC admin password in the credential vault: " + str(ex) + "}}xx", log_level=1)
         return False
 
-def get_password(username):
-    """Get password from the credential vault"""
+def get_smc_password(username):
+    """Get SMC admin password from the credential vault"""
     from common.color import p
     
     try:
-        credential_data = win32cred.CredRead(f"{username}", win32cred.CRED_TYPE_GENERIC)
+        credential_data = win32cred.CredRead(f"SMC_{username}", win32cred.CRED_TYPE_GENERIC)
         return credential_data["CredentialBlob"].decode('utf-16le')
     except Exception as ex:
-        p("}}ynNo password found for " + username + " in the credential vault " + str(ex) + "}}xx", log_level=1)
+        p("}}ynNo SMC admin password found for " + username + " in the credential vault " + str(ex) + "}}xx", log_level=1)
         return None
 
 

--- a/credential/README.md
+++ b/credential/README.md
@@ -30,8 +30,8 @@ Every failure path is logged, and critical steps will stop execution with the co
     -   **For `credential.exe`**, you can right-click the file and select "Run as administrator".
     -   **For `credential.py`**, follow step 3 below.
 
-3. **for running `credential.py` (skip this step when running `credential.exe`):**
-    you will need to open your terminal (e.g., PowerShell or Command Prompt) as an administrator before running the script  
+3. **For running `credential.py` (skip this step when running `credential.exe`):**
+    You will need to open your terminal (e.g., PowerShell or Command Prompt) as an administrator before running the script.
    ```powershell
    cd path\to\repo
    python -m venv venv # if not already created
@@ -71,19 +71,10 @@ This file contains all the settings for the credentialing process. Below is a de
 
 ---
 
-### `smc_url`
+### `is_domain_joined`
 
--   **Description**: The URL for the Student Management Console (SMC).
--   **Acceptable Values**: A valid URL string.
--   **Example**: `"https://smc.corrections.sbctc.edu/"`
--   **Required**: Yes
-
----
-
-### `smc_admin_username`
-
--   **Description**: The username for an admin account on the SMC. This is used to verify the student's account.
--   **Acceptable Values**: A valid SMC admin username string.
+-   **Description**: A boolean value to determine if the student username should be checked in Active Directory and full security policies applied. Setting this to `false` is useful for partially testing the credential process. Always set this to `true` for the complete credential process.
+-   **Acceptable Values**: `true`, `false` (boolean)
 -   **Required**: Yes
 
 ---
@@ -99,14 +90,15 @@ This file contains all the settings for the credentialing process. Below is a de
 ### `approved_nics`
 
 - **Description**: A JSON-encoded string representing a list of approved network adapters and their allowed IP subnets.
-- **Acceptable Values**: A valid JSON string that decodes to a list of lists, each containing a network card name and its associated allowed subnet in CIDR notation. Subent can be partial.
+- **Acceptable Values**: A valid JSON string that decodes to a list of lists, each containing a network card name and its associated allowed subnet in CIDR notation. Subnet can be partial.
 - **Example**: `[[ \"nic_name #1\", \"subnet #1\" ], [ \"nic_name #2\", \"subnet #2\" ]]`
-- **Required**:No (it would use what's in SMC by default, if that is empty you would be prompted. If what you enter in approved_nics matches SMC, approved_nics value in Windows registry will be duplicated)
+- **Required**: No (If that is empty, you will be prompted.)
 
+---
 
 ### `services_path`
 
--   **Description**: The relative path to the directory from root project containing the OPE services, including `mgmt.exe`.
+-   **Description**: The relative path from the project root to the directory containing the OPE services, including `mgmt.exe`.
 -   **Acceptable Values**: A string representing a valid path.
 -   **Example**: `"Services"`
 -   **Required**: Yes
@@ -115,7 +107,7 @@ This file contains all the settings for the credentialing process. Below is a de
 
 ### `vc_runtimes_script`
 
--   **Description**: The relative path to the directory from root project to the script used for installing for installing the Visual C++ runtimes.
+-   **Description**: The relative path from the project root to the script used for installing the Visual C++ runtimes.
 -   **Acceptable Values**: A string representing a valid path to a `.cmd` or `.bat` file.
 -   **Example**: `"bin/install_vc_runtimes.cmd"`
 -   **Required**: Yes
@@ -124,7 +116,7 @@ This file contains all the settings for the credentialing process. Below is a de
 
 ### `install_service_script`
 
--   **Description**: The relative path to the directory from root project to the script used for installing the OPE services.
+-   **Description**: The relative path from the project root to the script used for installing the OPE services.
 -   **Acceptable Values**: A string representing a valid path to a `.cmd` or `.bat` file.
 -   **Example**: `"bin/install_service.cmd"`
 -   **Required**: Yes
@@ -140,13 +132,14 @@ This file contains all the settings for the credentialing process. Below is a de
 -   **Acceptable Values**: `"on"`, `"off"` (string)
 -   **Required**: No
 
+---
 
 ### Runtime Behaviour Influenced by Configuration
 
 - `install_vc_runtimes=false` logs the choice and continues without invoking the batch installer.
 - `debug="on"` sets the working directory to the project root, runs `mgmt` via Python, skips service installation, and bypasses the confirmation prompt.
 - When not in debug mode the script expects `mgmt.exe` to exist under `services_path\mgmt\mgmt.exe`; missing files raise errors and halt the process.
-- Registry values written by the script (`smc_url`, `student_user`, `debug`, etc.) feed the downstream `mgmt` credential flow.
+- Registry values written by the script (`is_domain_joined`, `student_user`, `debug`, etc.) feed the downstream `mgmt` credential flow.
 
 ### Error Handling
 

--- a/credential/README.md
+++ b/credential/README.md
@@ -134,18 +134,18 @@ This file contains all the settings for the credentialing process. Below is a de
 
 ### `smc_url`
 
--   **Description**: Optional. The URL for the Student Management Console (SMC). When set (along with `smc_admin_username`), the credential process will fetch Canvas student access tokens from SMC during credentialing. If empty, SMC integration is skipped entirely.
+-   **Description**: Optional. The URL for the Student Management Console (SMC). When set (along with `smc_admin_username`), the credential process will fetch Canvas student access tokens from SMC during credentialing. If both are empty, SMC integration is skipped entirely.
 -   **Acceptable Values**: A valid HTTPS URL string, or `""` to disable.
 -   **Example**: `"https://smc.corrections.sbctc.edu"`
--   **Required**: No
+-   **Required**: No (required if `smc_admin_username` is non-empty; whitespace-only counts as empty)
 
 ---
 
 ### `smc_admin_username`
 
--   **Description**: Optional. The SMC admin username used for authenticated API calls. Required if `smc_url` is set. The corresponding password is stored securely in the Windows Credential Vault on first run (you will be prompted if no stored password is found).
+-   **Description**: Optional. The SMC admin username used for authenticated API calls. Required if `smc_url` is non-empty. The corresponding password is stored securely in the Windows Credential Vault on first run (you will be prompted if no stored password is found).
 -   **Acceptable Values**: A valid SMC admin username string, or `""` to disable.
--   **Required**: No (required if `smc_url` is set)
+-   **Required**: No (required if `smc_url` is non-empty; whitespace-only counts as empty)
 
 ---
 

--- a/credential/README.md
+++ b/credential/README.md
@@ -79,6 +79,15 @@ This file contains all the settings for the credentialing process. Below is a de
 
 ---
 
+### `base_dn`
+
+-   **Description**: The LDAP base Distinguished Name used to verify the student account in Active Directory. When `is_domain_joined` is `true`, the script queries Active Directory under this DN to confirm the student username exists. The value follows standard LDAP DN syntax with `OU=` (Organizational Unit) and `DC=` (Domain Component) parts. If is_domain_joined is set to false this could be an empty string otherwise values here will be ignored.
+-   **Acceptable Values**: A valid LDAP distinguished name string.
+-   **Example**: `"OU=Student Users,DC=school,DC=example,DC=org"`
+-   **Required**: Yes
+
+---
+
 ### `student_username`
 
 -   **Description**: The username of the student whose account will be set up on the laptop.

--- a/credential/README.md
+++ b/credential/README.md
@@ -132,6 +132,23 @@ This file contains all the settings for the credentialing process. Below is a de
 
 ---
 
+### `smc_url`
+
+-   **Description**: Optional. The URL for the Student Management Console (SMC). When set (along with `smc_admin_username`), the credential process will fetch Canvas student access tokens from SMC during credentialing. If empty, SMC integration is skipped entirely.
+-   **Acceptable Values**: A valid HTTPS URL string, or `""` to disable.
+-   **Example**: `"https://smc.corrections.sbctc.edu"`
+-   **Required**: No
+
+---
+
+### `smc_admin_username`
+
+-   **Description**: Optional. The SMC admin username used for authenticated API calls. Required if `smc_url` is set. The corresponding password is stored securely in the Windows Credential Vault on first run (you will be prompted if no stored password is found).
+-   **Acceptable Values**: A valid SMC admin username string, or `""` to disable.
+-   **Required**: No (required if `smc_url` is set)
+
+---
+
 ### `debug`
 
 -   **Description**: Enables or disables debug mode. When `"on"`, the script will:
@@ -149,6 +166,7 @@ This file contains all the settings for the credentialing process. Below is a de
 - `debug="on"` sets the working directory to the project root, runs `mgmt` via Python, skips service installation, and bypasses the confirmation prompt.
 - When not in debug mode the script expects `mgmt.exe` to exist under `services_path\mgmt\mgmt.exe`; missing files raise errors and halt the process.
 - Registry values written by the script (`is_domain_joined`, `student_user`, `debug`, etc.) feed the downstream `mgmt` credential flow.
+- When `smc_url` and `smc_admin_username` are configured, the credential process validates SMC connectivity and admin credentials early in the pipeline. During the `mgmt credential_laptop` step, the system will also fetch Canvas student access tokens from SMC and store them in the registry.
 
 ### Error Handling
 

--- a/credential/README.md
+++ b/credential/README.md
@@ -13,7 +13,7 @@ At a high level the process performs the following:
 - Confirms the JSON configuration is complete and operator has locked down the BIOS.
 - Verifies the session is elevated (UAC/Admin) before proceeding.
 - Caches configuration data in the registry for downstream services.
-- Pulls SMC configuration, confirms the target student account, and syncs NIC/time settings.
+- Confirms the target student account, and syncs NIC/time settings.
 - Orchestrates `mgmt.exe` commands to unlock the machine, credential the laptop, add Defender exclusions, install services, and relock the device.
 
 Every failure path is logged, and critical steps will stop execution with the correct exit code so the laptop is not handed to students in an unfinished state.
@@ -23,7 +23,7 @@ Every failure path is logged, and critical steps will stop execution with the co
 1.  **Configure `credential_config.json`**:
     -   Open the `credential_config.json` file.
     -   Update the values for each key according to your setup. See the "Configuration" section below for details on each setting.
-    -   Pay special attention to `smc_admin_username` and `student_username`, though you may enter `student_username` at runtime.
+    -   Pay special attention to `is_domain_joined` and `student_username`, though you may enter `student_username` at runtime.
 
 2.  **Run as Administrator**:
     -   The script requires administrative privileges to perform tasks like installing software, modifying system settings, and accessing the registry.

--- a/credential/README.md
+++ b/credential/README.md
@@ -101,7 +101,7 @@ This file contains all the settings for the credentialing process. Below is a de
 - **Description**: A JSON-encoded string representing a list of approved network adapters and their allowed IP subnets.
 - **Acceptable Values**: A valid JSON string that decodes to a list of lists, each containing a network card name and its associated allowed subnet in CIDR notation. Subnet can be partial.
 - **Example**: `[[ \"nic_name #1\", \"subnet #1\" ], [ \"nic_name #2\", \"subnet #2\" ]]`
-- **Required**: No (If that is empty, you will be prompted.)
+- **Required**: No (If that is empty, you will be prompted if registry value for approved nics doesn't exist already.)
 
 ---
 

--- a/credential/build_credential.cmd
+++ b/credential/build_credential.cmd
@@ -48,6 +48,12 @@ if exist "%CURRENT_DIR%credential_config.json" (
     echo Configuration file copied to dist directory.
 )
 
+rem copy readme file to dist directory
+if exist "%CURRENT_DIR%README.md" (
+    copy "%CURRENT_DIR%README.md" "%DIST_OUT%\credential\"
+    echo Readme file copied to dist directory.
+)
+
 echo Ready for deployment!
 echo You can now distribute the contents of: %DIST_OUT%\credential
 echo.

--- a/credential/credential.py
+++ b/credential/credential.py
@@ -334,8 +334,8 @@ class CredentialProcess:
         RegistrySettings.set_reg_value(value_name="debug", value=debug, value_type="REG_SZ")
         RegistrySettings.set_reg_value(value_name="base_dn", value=base_dn, value_type="REG_SZ")
 
-        smc_url = self.config.get('smc_url', '')
-        smc_admin_username = self.config.get('smc_admin_username', '')
+        smc_url = (self.config.get('smc_url') or '').strip()
+        smc_admin_username = (self.config.get('smc_admin_username') or '').strip()
         if smc_url and smc_admin_username:
             RegistrySettings.set_reg_value(value_name="smc_url", value=smc_url, value_type="REG_SZ")
             RegistrySettings.set_reg_value(value_name="smc_admin_user", value=smc_admin_username, value_type="REG_SZ")
@@ -397,19 +397,23 @@ class CredentialProcess:
             p("}}rbERROR: Unable to reach SMC at " + smc_url + " -- check the URL and network.}}xx", log_level=1)
             return False
 
-        smc_admin_password = util.get_password(smc_admin_username)
+        smc_admin_password = util.get_smc_password(smc_admin_username)
         if not smc_admin_password:
-            p("}}ynNo stored password found for SMC admin '" + smc_admin_username + "'.}}xx")
+            p("}}ynNo stored SMC admin password found for '" + smc_admin_username + "'.}}xx")
             smc_admin_password = getpass.getpass("Enter SMC admin password: ")
-            if not smc_admin_password:
-                p("}}rbERROR: SMC admin password cannot be empty.}}xx", log_level=1)
-                return False
+            while not RestClient.validate_smc_credentials(smc_url, smc_admin_username, smc_admin_password):
+                p("}}rbERROR: SMC rejected the admin credentials -- check username/password and try again.}}xx", log_level=1)
+                smc_admin_password = getpass.getpass("Enter SMC admin password: ")
 
-        if not RestClient.validate_smc_credentials(smc_url, smc_admin_username, smc_admin_password):
+            util.store_smc_password(smc_admin_username, smc_admin_password)
+            p("}}gnSMC credentials validated and stored successfully.}}xx")
+            return True
+
+        while not RestClient.validate_smc_credentials(smc_url, smc_admin_username, smc_admin_password):
             p("}}rbERROR: SMC rejected the admin credentials -- check username/password and try again.}}xx", log_level=1)
-            return False
+            smc_admin_password = getpass.getpass("Enter SMC admin password: ")
 
-        util.store_password(smc_admin_username, smc_admin_password)
+        util.store_smc_password(smc_admin_username, smc_admin_password)
         p("}}gnSMC credentials validated and stored successfully.}}xx")
         return True
 
@@ -473,6 +477,13 @@ class CredentialProcess:
             if val is not None and not isinstance(val, str):
                 p("}}rbERROR: " + key + " must be a string value (check credential_config.json).}}xx", log_level=1)
                 return False
+
+        smc_url = (self.config.get('smc_url') or '').strip()
+        smc_admin_username = (self.config.get('smc_admin_username') or '').strip()
+        if bool(smc_url) != bool(smc_admin_username):
+            p("}}rbERROR: smc_url and smc_admin_username must both be non-empty or both empty — "
+              "set both for SMC/Canvas token integration, or clear both to skip.}}xx", log_level=1)
+            return False
 
         approved_nics_str = self.config.get('approved_nics', '')
         if approved_nics_str != "" and approved_nics_str != "[]":

--- a/credential/credential.py
+++ b/credential/credential.py
@@ -315,9 +315,9 @@ class CredentialProcess:
         is_domain_joined = self.config.get('is_domain_joined', False)
 
         if is_domain_joined:
-            RegistrySettings.set_reg_value(value_name="is_domian_joined", value=True, value_type="REG_DWORD")
+            RegistrySettings.set_reg_value(value_name="is_domain_joined", value=True, value_type="REG_DWORD")
         else:
-            RegistrySettings.set_reg_value(value_name="is_domian_joined", value=False, value_type="REG_DWORD")
+            RegistrySettings.set_reg_value(value_name="is_domain_joined", value=False, value_type="REG_DWORD")
 
         RegistrySettings.set_reg_value(value_name="student_user", value=student_user, value_type="REG_SZ")
         RegistrySettings.set_reg_value(value_name="debug", value=debug, value_type="REG_SZ")
@@ -375,7 +375,7 @@ class CredentialProcess:
             # update the registry with the new student username
             RegistrySettings.set_reg_value(value_name="student_user", value=student_username, value_type="REG_SZ")
         
-        is_domain_joined = RegistrySettings.get_reg_value(value_name="is_domian_joined", default=False)
+        is_domain_joined = RegistrySettings.get_reg_value(value_name="is_domain_joined", default=False)
         if not is_domain_joined:
             p("}}laptop is not domain joined, skipping student account validation...}}xx")
             return True

--- a/credential/credential.py
+++ b/credential/credential.py
@@ -340,12 +340,16 @@ class CredentialProcess:
             return True
 
         approved_nics_str = RegistrySettings.get_reg_value(app="OPEService", value_name="approved_nics", default=None)
-
-        approved_nics = json.loads(approved_nics_str)
         
+        try:
+            approved_nics = json.loads(approved_nics_str) if approved_nics_str is not None else None
+        except (json.JSONDecodeError, TypeError):
+            approved_nics = None
+
         if not self.is_valid_approved_nics(approved_nics):
             p("}}gnNo approved NICs found or invalid format, configuring NICs...}}xx")
-            RegistrySettings.remove_reg_value(app="OPEService", value_name="approved_nics")
+            if approved_nics_str is not None:
+                RegistrySettings.remove_reg_value(app="OPEService", value_name="approved_nics")
             NetworkDevices.configure_nics()
         else:
             p("}}gnApproved NICs: " + approved_nics_str + "}}xx")
@@ -377,7 +381,7 @@ class CredentialProcess:
         
         is_domain_joined = RegistrySettings.get_reg_value(value_name="is_domain_joined", default=False)
         if not is_domain_joined:
-            p("}}laptop is not domain joined, skipping student account validation...}}xx")
+            p("}}ynlaptop is not domain joined, skipping student account validation...}}xx")
             return True
 
         base_dn = RegistrySettings.get_reg_value(value_name="base_dn", default="")

--- a/credential/credential.py
+++ b/credential/credential.py
@@ -117,7 +117,7 @@ class CredentialProcess:
         for key, value in self.config.items():
             p("}}yn" + key.replace('_', ' ').title() + ": }}cn" + str(value) + "}}xx")
         
-        p("}}gb=================================}}xx\n")
+        p("}}gb=================================}}xx")
 
         if self.config.get('debug', 'off').lower() == "on":
             return True

--- a/credential/credential.py
+++ b/credential/credential.py
@@ -312,6 +312,12 @@ class CredentialProcess:
         student_user = self.config.get('student_username', '')
         debug = self.config.get('debug', 'off')
         base_dn = self.config.get('base_dn', '')
+        is_domain_joined = self.config.get('is_domain_joined', False)
+
+        if is_domain_joined:
+            RegistrySettings.set_reg_value(value_name="is_domian_joined", value=True, value_type="REG_DWORD")
+        else:
+            RegistrySettings.set_reg_value(value_name="is_domian_joined", value=False, value_type="REG_DWORD")
 
         RegistrySettings.set_reg_value(value_name="student_user", value=student_user, value_type="REG_SZ")
         RegistrySettings.set_reg_value(value_name="debug", value=debug, value_type="REG_SZ")
@@ -357,7 +363,7 @@ class CredentialProcess:
     def validate_and_store_student_account(self):
         """Validate student account exists in SMC and get account details"""
         p("}}gb-- Validating and storing student account...}}xx")
-        student_username = self.config.get('student_username', '')
+        student_username = RegistrySettings.get_reg_value(value_name="student_user", default="")
 
         if not student_username:
             p("}}cnStudent username not set, please enter it now:}}xx")
@@ -368,28 +374,19 @@ class CredentialProcess:
             self.config['student_username'] = student_username
             # update the registry with the new student username
             RegistrySettings.set_reg_value(value_name="student_user", value=student_username, value_type="REG_SZ")
+        
+        is_domain_joined = RegistrySettings.get_reg_value(value_name="is_domian_joined", default=False)
+        if not is_domain_joined:
+            p("}}laptop is not domain joined, skipping student account validation...}}xx")
+            return True
 
-        base_dn = self.config.get('base_dn', '')
-        result, error = util.verify_student_account_in_ad(student_username, base_dn)
-        if not result:
-            p("}}rbERROR: Unable to verify student account in Active Directory: " + error + "}}xx", log_level=1)
+        base_dn = RegistrySettings.get_reg_value(value_name="base_dn", default="")
+        success, msg = util.verify_student_account_in_ad(student_username, base_dn)
+        if not success:
+            p("}}rbERROR: Unable to verify student account in Active Directory: " + msg + "}}xx", log_level=1)
             return False
-
-        # TODO - what to do if it's not a domain member? do we stop credentialing? or add a flag to continue? ask about standalone mode?
-        # do we need to distinguish between domain member and standalone mode anymore?
-
-        laptop_network_type = "Domain Member"
-        RegistrySettings.set_reg_value(value_name="laptop_network_type", value=laptop_network_type, value_type="REG_SZ")
-
-
-        p("}}gnStudent account validated and stored successfully}}xx")
-        return True
-
-    def store_laptop_network_type(self):
-        """Store the laptop network type in the registry"""
-        p("}}gb-- Storing laptop network type in the registry...}}xx")
-        laptop_network_type = self.config.get('laptop_network_type', '')
-        RegistrySettings.set_reg_value(value_name="laptop_network_type", value=laptop_network_type, value_type="REG_SZ")
+        RegistrySettings.set_reg_value(value_name="student_name", value=msg, value_type="REG_SZ")
+        p("}}gnStudent account validated and stored successfully: " + msg + "}}xx")
         return True
 
     def validate_config_settings(self):
@@ -398,9 +395,10 @@ class CredentialProcess:
 
         install_vc_runtimes = self.config.get('install_vc_runtimes', False)
         have_you_locked_down_the_bios = self.config.get('have_you_locked_down_the_bios', False)
+        is_domain_joined = self.config.get('is_domain_joined', False)
 
-        if not isinstance(install_vc_runtimes, bool) or not isinstance(have_you_locked_down_the_bios, bool):
-            p("}}rbERROR: install_vc_runtimes and have_you_locked_down_the_bios must be a boolean value (true or false).}}xx", log_level=1)
+        if not isinstance(install_vc_runtimes, bool) or not isinstance(have_you_locked_down_the_bios, bool) or not isinstance(is_domain_joined, bool):
+            p("}}rbERROR: install_vc_runtimes, have_you_locked_down_the_bios, and is_domain_joined must be a boolean value (true or false).}}xx", log_level=1)
             return False
 
         if not have_you_locked_down_the_bios:

--- a/credential/credential.py
+++ b/credential/credential.py
@@ -3,6 +3,7 @@ OPE Credential Process
 Configures a laptop for student use by installing services, credentialing, and locking down security.
 """
 
+import getpass
 import os
 import sys
 import json
@@ -17,6 +18,7 @@ from common.color import p
 from common import util
 from mgmt.mgmt_EventLog import EventLog
 from mgmt.mgmt_RegistrySettings import RegistrySettings
+from mgmt.mgmt_RestClient import RestClient
 from mgmt.mgmt_SystemTime import SystemTime
 from mgmt.mgmt_NetworkDevices import NetworkDevices
 
@@ -323,6 +325,12 @@ class CredentialProcess:
         RegistrySettings.set_reg_value(value_name="debug", value=debug, value_type="REG_SZ")
         RegistrySettings.set_reg_value(value_name="base_dn", value=base_dn, value_type="REG_SZ")
 
+        smc_url = self.config.get('smc_url', '')
+        smc_admin_username = self.config.get('smc_admin_username', '')
+        if smc_url and smc_admin_username:
+            RegistrySettings.set_reg_value(value_name="smc_url", value=smc_url, value_type="REG_SZ")
+            RegistrySettings.set_reg_value(value_name="smc_admin_user", value=smc_admin_username, value_type="REG_SZ")
+
         p("}}gb-- Configuration stored in the registry...}}xx")
 
         return True
@@ -364,8 +372,40 @@ class CredentialProcess:
         
         return True
 
+    def validate_and_store_smc_credentials(self):
+        """Validate SMC connectivity and admin credentials when smc_url is configured.
+        Stores the admin password in the credential vault only after successful validation.
+        Returns True if SMC is not configured (skip) or validation passes."""
+        smc_url = self.config.get('smc_url', '')
+        smc_admin_username = self.config.get('smc_admin_username', '')
+
+        if not smc_url or not smc_admin_username:
+            return True
+
+        p("}}gb-- Validating SMC connectivity and credentials...}}xx")
+
+        if not RestClient.ping_smc(smc_url):
+            p("}}rbERROR: Unable to reach SMC at " + smc_url + " -- check the URL and network.}}xx", log_level=1)
+            return False
+
+        smc_admin_password = util.get_password(smc_admin_username)
+        if not smc_admin_password:
+            p("}}ynNo stored password found for SMC admin '" + smc_admin_username + "'.}}xx")
+            smc_admin_password = getpass.getpass("Enter SMC admin password: ")
+            if not smc_admin_password:
+                p("}}rbERROR: SMC admin password cannot be empty.}}xx", log_level=1)
+                return False
+
+        if not RestClient.validate_smc_credentials(smc_url, smc_admin_username, smc_admin_password):
+            p("}}rbERROR: SMC rejected the admin credentials -- check username/password and try again.}}xx", log_level=1)
+            return False
+
+        util.store_password(smc_admin_username, smc_admin_password)
+        p("}}gnSMC credentials validated and stored successfully.}}xx")
+        return True
+
     def validate_and_store_student_account(self):
-        """Validate student account exists in SMC and get account details"""
+        """Validate student account exists in Active Directory and get account details"""
         p("}}gb-- Validating and storing student account...}}xx")
         student_username = RegistrySettings.get_reg_value(value_name="student_user", default="")
 
@@ -418,11 +458,12 @@ class CredentialProcess:
                 p("}}rbERROR: " + key + " must be a string value (check credential_config.json).}}xx", log_level=1)
                 return False
 
-        # student_username is optional, but if it exists, it must be a string. None is also acceptable.
-        student_username = self.config.get('student_username')
-        if student_username is not None and not isinstance(student_username, str):
-            p("}}rbERROR: student_username must be a string value (check credential_config.json).}}xx", log_level=1)
-            return False
+        optional_string_keys = ['student_username', 'smc_url', 'smc_admin_username']
+        for key in optional_string_keys:
+            val = self.config.get(key)
+            if val is not None and not isinstance(val, str):
+                p("}}rbERROR: " + key + " must be a string value (check credential_config.json).}}xx", log_level=1)
+                return False
 
         approved_nics_str = self.config.get('approved_nics', '')
         if approved_nics_str != "" and approved_nics_str != "[]":
@@ -458,7 +499,7 @@ class CredentialProcess:
 
         self.store_config_in_registry()
         
-        initial_checks = (self.validate_and_store_student_account, self.configure_network_devices, self.sync_time_with_ntp)
+        initial_checks = (self.validate_and_store_smc_credentials, self.validate_and_store_student_account, self.configure_network_devices, self.sync_time_with_ntp)
         for check in initial_checks:
             if not check():
                 p("}}rbInitial check failed: " + check.__name__ + "}}xx", log_level=1)

--- a/credential/credential.py
+++ b/credential/credential.py
@@ -311,36 +311,14 @@ class CredentialProcess:
         """Store the configuration in the registry to be used by the credential_laptop function in mgmt module"""
         p("}}gb-- Storing configuration in the registry...}}xx")
 
-        smc_url = self.config.get('smc_url', '')
-        smc_admin_user = self.config.get('smc_admin_username', '')
         student_user = self.config.get('student_username', '')
         debug = self.config.get('debug', 'off')
 
-        RegistrySettings.set_reg_value(value_name="smc_url", value=smc_url, value_type="REG_SZ")
-        RegistrySettings.set_reg_value(value_name="smc_admin_user", value=smc_admin_user, value_type="REG_SZ")
         RegistrySettings.set_reg_value(value_name="student_user", value=student_user, value_type="REG_SZ")
         RegistrySettings.set_reg_value(value_name="debug", value=debug, value_type="REG_SZ")
 
         p("}}gb-- Configuration stored in the registry...}}xx")
 
-        return True
-
-    def validate_and_store_smc_config(self):
-        """Validate the SMC configuration"""
-        smc_url = self.config.get('smc_url', '')
-        if smc_url == "":
-            p("}}rbERROR: SMC URL is not set.}}xx", log_level=1)
-            return False
-        
-        smc_config = RestClient.get_smc_config(smc_url)
-        if smc_config is None:
-            p("}}rbERROR: Unable to get SMC configuration.}}xx", log_level=1)
-            return False
-        
-        p("}}gnSMC configuration: " + str(smc_config) + "}}xx")
-
-        RegistrySettings.store_smc_config(smc_config)
-        
         return True
 
     def configure_network_devices(self):
@@ -379,13 +357,7 @@ class CredentialProcess:
     def validate_and_store_student_account(self):
         """Validate student account exists in SMC and get account details"""
         p("}}gb-- Validating and storing student account...}}xx")
-        smc_url = self.config.get('smc_url', '')
-        smc_admin_username = self.config.get('smc_admin_username', '')
         student_username = self.config.get('student_username', '')
-
-        if not all([smc_url, smc_admin_username]):
-            p("}}rbERROR: SMC URL, or admin username is not set.}}xx", log_level=1)
-            return False
 
         if not student_username:
             p("}}cnStudent username not set, please enter it now:}}xx")
@@ -398,28 +370,22 @@ class CredentialProcess:
             RegistrySettings.set_reg_value(value_name="student_user", value=student_username, value_type="REG_SZ")
 
 
-        smc_admin_password = util.get_smc_password(smc_admin_username)
-        if smc_admin_password is None:
-            smc_admin_password = getpass.getpass(prompt=f"Enter SMC admin password:")
-            if not util.store_smc_password(smc_admin_username, smc_admin_password):
-                return False
-        
-        result = RestClient.verify_ope_account_in_smc(student_username, smc_url, smc_admin_username, smc_admin_password)
-        if result is None:
-            p("}}rbERROR: Unable to verify student account in SMC.}}xx", log_level=1)
-            return False
+        # TODO - Add active directory student username check here instead of SMC
+        # result = RestClient.verify_ope_account_in_smc(student_username, smc_url, smc_admin_username, smc_admin_password)
+        # if result is None:
+        #     p("}}rbERROR: Unable to verify student account in SMC.}}xx", log_level=1)
+        #     return False
 
         # Store the returned information in registry for later use
-        laptop_admin_user, student_full_name, smc_version, \
-        laptop_network_type, laptop_domain_name, laptop_domain_ou = result
+        # laptop_admin_user, student_full_name, \
+        # laptop_network_type, laptop_domain_name, laptop_domain_ou = result
 
         # Store these values in registry
-        RegistrySettings.set_reg_value(value_name="laptop_admin_user", value=laptop_admin_user, value_type="REG_SZ")
-        RegistrySettings.set_reg_value(value_name="student_full_name", value=student_full_name, value_type="REG_SZ")
-        RegistrySettings.set_reg_value(value_name="smc_version", value=smc_version, value_type="REG_SZ")
-        RegistrySettings.set_reg_value(value_name="laptop_network_type", value=laptop_network_type, value_type="REG_SZ")
-        RegistrySettings.set_reg_value(value_name="laptop_domain_name", value=laptop_domain_name, value_type="REG_SZ")
-        RegistrySettings.set_reg_value(value_name="laptop_domain_ou", value=laptop_domain_ou, value_type="REG_SZ")
+        # RegistrySettings.set_reg_value(value_name="laptop_admin_user", value=laptop_admin_user, value_type="REG_SZ")
+        # RegistrySettings.set_reg_value(value_name="student_full_name", value=student_full_name, value_type="REG_SZ")
+        # RegistrySettings.set_reg_value(value_name="laptop_network_type", value=laptop_network_type, value_type="REG_SZ")
+        # RegistrySettings.set_reg_value(value_name="laptop_domain_name", value=laptop_domain_name, value_type="REG_SZ")
+        # RegistrySettings.set_reg_value(value_name="laptop_domain_ou", value=laptop_domain_ou, value_type="REG_SZ")
 
         p("}}gnStudent account validated and stored successfully}}xx")
         return True
@@ -440,8 +406,7 @@ class CredentialProcess:
             return False
 
         string_keys = [
-            'smc_url', 'smc_admin_username',
-            'services_path', 'vc_runtimes_script', 'install_service_script'
+            'smc_url', 'services_path', 'vc_runtimes_script', 'install_service_script'
         ]
         for key in string_keys:
             value = self.config.get(key)
@@ -489,11 +454,10 @@ class CredentialProcess:
 
         self.store_config_in_registry()
         
-        initial_checks = (self.validate_and_store_smc_config, self.validate_and_store_student_account, self.configure_network_devices, self.sync_time_with_ntp)
+        initial_checks = (self.validate_and_store_student_account, self.configure_network_devices, self.sync_time_with_ntp)
         for check in initial_checks:
             if not check():
                 p("}}rbInitial check failed: " + check.__name__ + "}}xx", log_level=1)
-                RegistrySettings.set_reg_value(value_name="credential_config", value=False, value_type="REG_DWORD")
                 return EXIT_ERROR
         
         # Execute workflow steps

--- a/credential/credential.py
+++ b/credential/credential.py
@@ -233,8 +233,7 @@ class CredentialProcess:
     
     def unlock_machine(self):
         """Unlock machine to disable security settings for credential process"""
-        p("}}gb-- Unlocking Machine - please wait...}}xx")
-        p("")
+        p("}}gb-- Unlocking Machine...}}xx")
         
         mgmt_exe = self.get_mgmt_exe_path()
         if not mgmt_exe:

--- a/credential/credential.py
+++ b/credential/credential.py
@@ -8,7 +8,6 @@ import sys
 import json
 import subprocess
 import ctypes
-import getpass
 
 # Add parent directory to path so we can import common and mgmt modules
 parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -18,7 +17,6 @@ from common.color import p
 from common import util
 from mgmt.mgmt_EventLog import EventLog
 from mgmt.mgmt_RegistrySettings import RegistrySettings
-from mgmt.mgmt_RestClient import RestClient
 from mgmt.mgmt_SystemTime import SystemTime
 from mgmt.mgmt_NetworkDevices import NetworkDevices
 
@@ -313,9 +311,11 @@ class CredentialProcess:
 
         student_user = self.config.get('student_username', '')
         debug = self.config.get('debug', 'off')
+        base_dn = self.config.get('base_dn', '')
 
         RegistrySettings.set_reg_value(value_name="student_user", value=student_user, value_type="REG_SZ")
         RegistrySettings.set_reg_value(value_name="debug", value=debug, value_type="REG_SZ")
+        RegistrySettings.set_reg_value(value_name="base_dn", value=base_dn, value_type="REG_SZ")
 
         p("}}gb-- Configuration stored in the registry...}}xx")
 
@@ -369,25 +369,27 @@ class CredentialProcess:
             # update the registry with the new student username
             RegistrySettings.set_reg_value(value_name="student_user", value=student_username, value_type="REG_SZ")
 
+        base_dn = self.config.get('base_dn', '')
+        result, error = util.verify_student_account_in_ad(student_username, base_dn)
+        if not result:
+            p("}}rbERROR: Unable to verify student account in Active Directory: " + error + "}}xx", log_level=1)
+            return False
 
-        # TODO - Add active directory student username check here instead of SMC
-        # result = RestClient.verify_ope_account_in_smc(student_username, smc_url, smc_admin_username, smc_admin_password)
-        # if result is None:
-        #     p("}}rbERROR: Unable to verify student account in SMC.}}xx", log_level=1)
-        #     return False
+        # TODO - what to do if it's not a domain member? do we stop credentialing? or add a flag to continue? ask about standalone mode?
+        # do we need to distinguish between domain member and standalone mode anymore?
 
-        # Store the returned information in registry for later use
-        # laptop_admin_user, student_full_name, \
-        # laptop_network_type, laptop_domain_name, laptop_domain_ou = result
+        laptop_network_type = "Domain Member"
+        RegistrySettings.set_reg_value(value_name="laptop_network_type", value=laptop_network_type, value_type="REG_SZ")
 
-        # Store these values in registry
-        # RegistrySettings.set_reg_value(value_name="laptop_admin_user", value=laptop_admin_user, value_type="REG_SZ")
-        # RegistrySettings.set_reg_value(value_name="student_full_name", value=student_full_name, value_type="REG_SZ")
-        # RegistrySettings.set_reg_value(value_name="laptop_network_type", value=laptop_network_type, value_type="REG_SZ")
-        # RegistrySettings.set_reg_value(value_name="laptop_domain_name", value=laptop_domain_name, value_type="REG_SZ")
-        # RegistrySettings.set_reg_value(value_name="laptop_domain_ou", value=laptop_domain_ou, value_type="REG_SZ")
 
         p("}}gnStudent account validated and stored successfully}}xx")
+        return True
+
+    def store_laptop_network_type(self):
+        """Store the laptop network type in the registry"""
+        p("}}gb-- Storing laptop network type in the registry...}}xx")
+        laptop_network_type = self.config.get('laptop_network_type', '')
+        RegistrySettings.set_reg_value(value_name="laptop_network_type", value=laptop_network_type, value_type="REG_SZ")
         return True
 
     def validate_config_settings(self):
@@ -406,7 +408,7 @@ class CredentialProcess:
             return False
 
         string_keys = [
-            'smc_url', 'services_path', 'vc_runtimes_script', 'install_service_script'
+            'base_dn', 'services_path', 'vc_runtimes_script', 'install_service_script'
         ]
         for key in string_keys:
             value = self.config.get(key)

--- a/credential/credential.py
+++ b/credential/credential.py
@@ -150,7 +150,7 @@ class CredentialProcess:
             p("}}rbERROR: Failed to check admin privileges: " + str(ex) + "}}xx", log_level=1)
             return False
     
-    def run_command(self, cmd, error_msg=None, critical=False):
+    def run_command(self, cmd, error_msg=None, critical=False, mgmt_log_to_credential=False):
         """
         Run a command and check return code
         
@@ -158,6 +158,8 @@ class CredentialProcess:
             cmd: Command to run
             error_msg: Error message to display on failure
             critical: If True, exit with EXIT_CRITICAL on failure
+            mgmt_log_to_credential: If True, child mgmt process logs to ope-credential.log
+                (via OPE_MGMT_LOG_FILE) instead of ope-mgmt.log.
             
         Returns:
             True on success, False on failure
@@ -171,7 +173,12 @@ class CredentialProcess:
             p("}}gnWorking directory is set to: " + cwd + "}}xx", log_level=4)
 
         try:
-            result = subprocess.run(cmd, shell=True, capture_output=False, cwd=cwd)    
+            env = None
+            if mgmt_log_to_credential:
+                env = os.environ.copy()
+                env["OPE_MGMT_LOG_FILE"] = os.path.abspath(os.path.expandvars(lf))
+
+            result = subprocess.run(cmd, shell=True, capture_output=False, cwd=cwd, env=env)
             if result.returncode != 0:
                 if error_msg:
                     p("}}rb" + error_msg + "}}xx", log_level=1)
@@ -236,7 +243,8 @@ class CredentialProcess:
         return self.run_command(
             f'{mgmt_exe} unlock_machine',
             error_msg="*** ERROR - Failed to unlock machine - Quitting. ***",
-            critical=True
+            critical=True,
+            mgmt_log_to_credential=True,
         )
     
     def install_services(self):
@@ -270,7 +278,8 @@ class CredentialProcess:
         return self.run_command(
             f'{mgmt_exe} credential_laptop',
             error_msg="****** Credential process did not complete properly - this Laptop is NOT ready to hand out to students. *******",
-            critical=True
+            critical=True,
+            mgmt_log_to_credential=True,
         )
     
     def lock_machine(self):
@@ -284,7 +293,8 @@ class CredentialProcess:
         return self.run_command(
             f'{mgmt_exe} lock_machine',
             error_msg="****** ERROR - Unable to lock machine. Credential process did not complete properly - this Laptop is NOT ready to hand out to students. Try mgmt lock_machine again to see if you can lock it manually. *******",
-            critical=True
+            critical=True,
+            mgmt_log_to_credential=True,
         )
     
     def display_completion(self):

--- a/credential/credential.py
+++ b/credential/credential.py
@@ -74,14 +74,14 @@ class CredentialConfig:
     
     def validate(self):
         """Validate required configuration settings"""
-        required_keys = ['install_vc_runtimes', 'have_you_locked_down_the_bios', 'services_path', 'vc_runtimes_script', 'install_service_script']
+        required_keys = ['install_vc_runtimes', 'have_you_locked_down_the_bios', 'services_path', 'vc_runtimes_script', 'install_service_script', 'is_domain_joined', 'base_dn']
         
         for key in required_keys:
             if key not in self.config:
                 p("}}rbERROR: Missing required configuration key: " + key + "}}xx", log_level=1)
                 p("}}rbThe following keys are required:")
                 for key in required_keys:
-                    p("}}yn" + key.replace('_', ' ').title() + "}}xx", log_level=1)
+                    p("}}yn" + key + "}}xx", log_level=1)
                 p("}}rbPlease edit the credential_config.json file and try again.}}xx", log_level=1)
                 return False
         

--- a/credential/credential_config.json
+++ b/credential/credential_config.json
@@ -1,6 +1,7 @@
 {
   "install_vc_runtimes": false,
   "have_you_locked_down_the_bios": true,
+  "is_domain_joined": true,
   "base_dn": "OU=, DC=,DC=,DC=",
   "student_username": "",
   "approved_nics": "",

--- a/credential/credential_config.json
+++ b/credential/credential_config.json
@@ -5,6 +5,8 @@
   "base_dn": "OU=, DC=,DC=,DC=",
   "student_username": "",
   "approved_nics": "",
+  "smc_url": "",
+  "smc_admin_username": "",
   "services_path": "Services", 
   "vc_runtimes_script": "bin/install_vc_runtimes.cmd",
   "install_service_script": "bin/install_service.cmd",

--- a/credential/credential_config.json
+++ b/credential/credential_config.json
@@ -1,5 +1,5 @@
 {
-  "install_vc_runtimes": false,
+  "install_vc_runtimes": true,
   "have_you_locked_down_the_bios": true,
   "is_domain_joined": true,
   "base_dn": "OU=, DC=,DC=,DC=",

--- a/credential/credential_config.json
+++ b/credential/credential_config.json
@@ -1,10 +1,9 @@
 {
   "install_vc_runtimes": false,
-  "have_you_locked_down_the_bios": false,
-  "smc_url": "https://smc.corrections.sbctc.edu/",
-  "smc_admin_username": "",
+  "have_you_locked_down_the_bios": true,
+  "base_dn": "OU=, DC=,DC=,DC=",
   "student_username": "",
-  "approved_nics": "[]",
+  "approved_nics": "",
   "services_path": "Services", 
   "vc_runtimes_script": "bin/install_vc_runtimes.cmd",
   "install_service_script": "bin/install_service.cmd",

--- a/mgmt/mgmt.py
+++ b/mgmt/mgmt.py
@@ -307,11 +307,6 @@ valid_commands = {
         "function": UserAccounts.remove_account_profile,
         "help": "Remove the windows profile for this account (e.g. mgmt remove_account_profile s777777)"
     },
-    # Download the OPE CA cert and add to the trusted list
-    "trust_ope_certs": {
-        "function": CredentialProcess.trust_ope_certs,
-        "help": "Download CA crt from the OPE server and add to the trusted list"
-    },
     # Lock the screen for the current user
     "lock_screen": {
         "function": UserAccounts.lock_screen_for_user,

--- a/mgmt/mgmt.py
+++ b/mgmt/mgmt.py
@@ -1,43 +1,23 @@
-# import pythoncom
-# import win32serviceutil
-# import win32service
-# import win32event
-# import servicemanager
-# import socket
-# import time
-# import datetime
-# import sys
-# import os
-# import logging
-# import random
-# # from win32com.shell import shell, shellcon
-# import ntsecuritycon
-# import win32security
-# import win32gui
-# import win32ui
-# import win32con
-# import win32gui_struct
-# import win32ts
-# import win32process
-# import win32profile
-# import ctypes
-# import wmi
-# import traceback
 import os
 
 # Required imports - helps nuitka
 import simplejson
 
 import win32trace
-import win32api
-import traceback
 
 from common import util
 
 # Pull in logger first and set it up!
 from mgmt_EventLog import EventLog
 global LOGGER
-LOGGER = EventLog(os.path.join(util.LOG_FOLDER, 'ope-mgmt.log'), service_name="OPEMgmt")
+# When credential.py (or another parent) spawns mgmt, it sets OPE_MGMT_LOG_FILE so logs
+# go to that file; direct mgmt runs use ope-mgmt.log.
+_mgmt_log_override = (os.environ.get("OPE_MGMT_LOG_FILE") or "").strip()
+if _mgmt_log_override:
+    _mgmt_log_path = os.path.expandvars(_mgmt_log_override)
+else:
+    _mgmt_log_path = os.path.join(util.LOG_FOLDER, "ope-mgmt.log")
+LOGGER = EventLog(_mgmt_log_path, service_name="OPEMgmt")
 
 from common.color import p, set_log_level
 

--- a/mgmt/mgmt_CredentialProcess.py
+++ b/mgmt/mgmt_CredentialProcess.py
@@ -130,7 +130,6 @@ class CredentialProcess:
             import secrets
             student_password = secrets.token_urlsafe(6)
             p("}}ynGenerated password for " + student_user + ": }}cb" + student_password + "}}xx")
-            util.store_password(student_user, student_password)
 
         CredentialProcess._fetch_canvas_token_from_smc(student_user)
 
@@ -193,7 +192,7 @@ class CredentialProcess:
 
                 import secrets
                 student_password = secrets.token_urlsafe(6)
-                util.store_password(student_user, student_password)
+                p("}}ynGenerated password for " + student_user + ": }}cb" + student_password + "}}xx")
 
             ad_info = "Domain Joined" if is_domain_joined else "Standalone"
             student_text = student_user + " (" + student_name + ")"
@@ -253,7 +252,7 @@ class CredentialProcess:
             return
 
         smc_admin_user = RegistrySettings.get_reg_value(value_name="smc_admin_user", default="")
-        smc_admin_password = util.get_password(smc_admin_user) if smc_admin_user else ""
+        smc_admin_password = util.get_smc_password(smc_admin_user) if smc_admin_user else ""
 
         if not smc_admin_user or not smc_admin_password:
             p("}}ybSMC URL is configured but admin credentials are missing -- skipping canvas token fetch.}}xx")

--- a/mgmt/mgmt_CredentialProcess.py
+++ b/mgmt/mgmt_CredentialProcess.py
@@ -129,6 +129,7 @@ class CredentialProcess:
         if not is_domain_joined:
             import secrets
             student_password = secrets.token_urlsafe(6)
+            p("}}ynGenerated password for " + student_user + ": }}cb" + student_password + "}}xx")
             util.store_password(student_user, student_password)
 
         return (student_user, student_name, student_password, is_domain_joined)
@@ -302,7 +303,8 @@ class CredentialProcess:
 
         if not is_domain_joined:
             p("}}gnCreating local student windows account...}}xx")
-            if not UserAccounts.create_local_student_account(student_user, student_name, student_password):
+            # student_name is the same as student_user for standalone mode (not domain joined)
+            if not UserAccounts.create_local_student_account(student_user, student_user, student_password):
                 p("}}rbError setting up OPE Student Account}}xx\n " + str(student_user))
                 return False
         else:
@@ -351,6 +353,11 @@ class CredentialProcess:
 
     @staticmethod
     def ensure_opeservice_running():
+        
+        if RegistrySettings.is_debug():
+            p("}}ynDEBUG MODE ON - Skipping ensure OPEService is running}}xx")
+            return True
+        
         ret = False
 
         w = Computer.get_wmi_connection()

--- a/mgmt/mgmt_CredentialProcess.py
+++ b/mgmt/mgmt_CredentialProcess.py
@@ -132,6 +132,8 @@ class CredentialProcess:
             p("}}ynGenerated password for " + student_user + ": }}cb" + student_password + "}}xx")
             util.store_password(student_user, student_password)
 
+        CredentialProcess._fetch_canvas_token_from_smc(student_user)
+
         return (student_user, student_name, student_password, is_domain_joined)
 
     @staticmethod
@@ -238,7 +240,46 @@ class CredentialProcess:
 
             loop_running = False
 
+        CredentialProcess._fetch_canvas_token_from_smc(student_user)
+
         return (student_user, student_name, student_password, is_domain_joined)
+
+    @staticmethod
+    def _fetch_canvas_token_from_smc(student_user):
+        """If smc_url is configured, call credential_student_in_smc to obtain canvas tokens
+        and store them in the registry. Skips silently when SMC is not configured."""
+        smc_url = RegistrySettings.get_reg_value(value_name="smc_url", default="")
+        if not smc_url:
+            return
+
+        smc_admin_user = RegistrySettings.get_reg_value(value_name="smc_admin_user", default="")
+        smc_admin_password = util.get_password(smc_admin_user) if smc_admin_user else ""
+
+        if not smc_admin_user or not smc_admin_password:
+            p("}}ybSMC URL is configured but admin credentials are missing -- skipping canvas token fetch.}}xx")
+            return
+
+        p("}}gnFetching canvas token from SMC...}}xx")
+        ex_info = CredentialProcess.COMPUTER_INFO
+        result = RestClient.credential_student_in_smc(
+            student_user, smc_url, smc_admin_user, smc_admin_password, ex_info
+        )
+
+        if result is None:
+            p("}}ybWARNING: Unable to fetch canvas token from SMC -- continuing without it.}}xx")
+            return
+
+        (student_full_name, canvas_url, canvas_access_token,
+            student_password_from_smc, laptop_admin_password) = result
+
+        RegistrySettings.store_credential_info(
+            student_user=student_user,
+            student_name=student_full_name,
+            is_domain_joined=bool(RegistrySettings.get_reg_value(value_name="is_domain_joined", default=0)),
+            canvas_access_token=canvas_access_token,
+            canvas_url=canvas_url,
+        )
+        p("}}gnCanvas token stored successfully.}}xx")
 
     @staticmethod
     def credential_input_verify_loop():

--- a/mgmt/mgmt_CredentialProcess.py
+++ b/mgmt/mgmt_CredentialProcess.py
@@ -49,14 +49,10 @@ class CredentialProcess:
         return ret
 
     @staticmethod
-    def get_credentialed_network_type():
-        # Return the name of the current credentialed student or None if missing
-        return RegistrySettings.get_reg_value(app="OPEService", value_name="laptop_network_type", default=None)
-    
-    @staticmethod
-    def get_credentialed_domain_name():
-        # Return the name of the current credentialed student or None if missing
-        return RegistrySettings.get_reg_value(app="OPEService", value_name="laptop_domain_name", default=None)
+    def is_credentialed_domain_joined():
+        """Return True if the credentialed laptop is domain-joined, False otherwise."""
+        val = RegistrySettings.get_reg_value(value_name="is_domain_joined", default=0)
+        return bool(val)
     
     @staticmethod
     def get_credentialed_student():
@@ -86,7 +82,6 @@ class CredentialProcess:
     def config_mgmt_utility():
         mgmt_version = CredentialProcess.get_mgmt_version()
 
-        # Setup local groups for students and admins
         UserAccounts.create_local_students_group()
         UserAccounts.create_local_admins_group()
 
@@ -102,87 +97,53 @@ class CredentialProcess:
             app="System\\CurrentControlSet\\Control\\Terminal Server",
             value_name="AllowRemoteRPC", value="1",
             value_type="REG_DWORD")
-        
-
-        smc_url = RegistrySettings.get_reg_value(value_name="smc_url", default="https://smc.corrections.sbctc.edu/")
 
         p("\n}}gbOPE Management Utility - Version: " + mgmt_version + "}}xx")
 
-        # 4 - Ask for input (smc server, login, student name, etc...)
-        p("}}ynEnter URL for SMC Server }}cn[enter for " + smc_url + "]:}}xx ", False)
-        tmp = input()
-        tmp = tmp.strip()
-        if tmp == "":
-            tmp = smc_url
-        smc_url = tmp
-        # Make sure url has https or http in it
-        if "https://" not in smc_url.lower() and "http://" not in smc_url.lower():
-            smc_url = "https://" + smc_url
-
-        p("}}gnSetting SMC URL to " + smc_url + "}}xx")
-        RegistrySettings.set_reg_value(value_name="smc_url", value=smc_url) 
-
-        # Getting config from SMC
-        smc_config = RestClient.get_smc_config(smc_url)
-        if smc_config is None:
-            p("}}rbError - Unable to get SMC Config!}}xx")
-            return False
-        
-        #p("}}gnSMC Config: " + str(smc_config) + "}}xx")
-        RegistrySettings.store_smc_config(smc_config)
-        
-        # Start time sync
         p("}}gnSyncing time with NTP servers...}}xx")
         SystemTime.sync_time_w_ntp(force=True)
-        
 
-        # Check on list of nics and make sure the current IP is added if desired...
         p("}}gnConfiguring Network Devices...}}xx")
         NetworkDevices.configure_nics()
 
-        # Doesn't work - group policy overwrites it every time it refreshes
-        # Make sure OPEAdmins can logon locally
-        #UserAccounts.allow_group_to_logon_locally("OPEAdmins")
-        # Remove the users group from logon locally
-        #UserAccounts.remove_group_from_logon_locally("Users")
-
         # Check if current user is in the OPEadmins group
         active_user = UserAccounts.get_active_user_name()
-        if not active_user is None and active_user.lower() != "system" and not UserAccounts.is_user_in_group(active_user, "OPEAdmins"):
-            # Add active user to OPEAdmins group
+        if active_user is not None and active_user.lower() != "system" and not UserAccounts.is_user_in_group(active_user, "OPEAdmins"):
             p("}}gnAdding current user (" + active_user + ") to OPEAdmins group...}}xx")
             UserAccounts.add_user_to_group(active_user, "OPEAdmins")
 
         return True
 
     @staticmethod
-    def credential_input_verify_loop():
-        # Loop until we quit or get good stuff
-
-        # Return a list of values
-        # student_full_name, laptop_admin_user, laptop_admin_password
-        ret = []
-
-        credential_config = RegistrySettings.get_reg_value(value_name="credential_config", default=False)
-        mgmt_version = CredentialProcess.get_mgmt_version()
-
-        canvas_url = ""
-        canvas_access_token = ""
+    def _get_student_info_from_registry():
+        """Read student info from registry (called from credential.py pipeline)."""
         student_user = RegistrySettings.get_reg_value(value_name="student_user", default="")
-        student_full_name = ""
-        student_password = ""
+        student_name = RegistrySettings.get_reg_value(value_name="student_name", default="")
+        is_domain_joined = bool(RegistrySettings.get_reg_value(value_name="is_domain_joined", default=0))
 
-        laptop_admin_user = ""
-        laptop_admin_password = ""
+        if not student_user:
+            p("}}rbNo student_user found in registry!}}xx")
+            return None
 
-        laptop_network_type = "Standalone"
-        laptop_domain_name = ""
-        laptop_domain_ou = "" 
+        student_password = None
+        if not is_domain_joined:
+            import secrets
+            student_password = secrets.token_urlsafe(6)
+            util.store_password(student_user, student_password)
+
+        return (student_user, student_name, student_password, is_domain_joined)
+
+    @staticmethod
+    def _get_student_info_interactive():
+        """Prompt for student info interactively (standalone mgmt invocation)."""
+        mgmt_version = CredentialProcess.get_mgmt_version()
+        student_user = RegistrySettings.get_reg_value(value_name="student_user", default="")
+        is_domain_joined = bool(RegistrySettings.get_reg_value(value_name="is_domain_joined", default=0))
+        base_dn = RegistrySettings.get_reg_value(value_name="base_dn", default="")
 
         loop_running = True
         while loop_running:
             p("\n}}gb Version: " + mgmt_version + "}}xx")
-            
             p("""
 
 }}mn======================================================================
@@ -193,77 +154,47 @@ class CredentialProcess:
 }}mn======================================================================}}xx
 
             """)
-            if not credential_config:
-                tmp = ""
-                last_student_user_prompt = ""
-                while tmp.strip() == "":
-                    if student_user != "":
-                        last_student_user_prompt = " }}cn[enter for previous student " + student_user + "]"
-                        # p("}}mb\t- Found previously credentialed user: }}xx" + str(last_student_user))
-                    p("}}ynPlease enter the username for the student" + last_student_user_prompt + ":}}xx ", False)
-                    tmp = input()
-                    if tmp.lower() == "quit":
-                        p("}}rnGot QUIT - exiting credential!}}xx")
+
+            tmp = ""
+            last_student_user_prompt = ""
+            while tmp.strip() == "":
+                if student_user != "":
+                    last_student_user_prompt = " }}cn[enter for previous student " + student_user + "]"
+                p("}}ynPlease enter the username for the student" + last_student_user_prompt + ":}}xx ", False)
+                tmp = input()
+                if tmp.lower() == "quit":
+                    p("}}rnGot QUIT - exiting credential!}}xx")
+                    return None
+                if tmp.strip() == "":
+                    tmp = student_user
+            student_user = tmp.strip()
+
+            student_name = ""
+            student_password = None
+
+            if is_domain_joined:
+                if base_dn:
+                    success, result_msg = util.verify_student_account_in_ad(student_user, base_dn)
+                    if not success:
+                        p("}}rbUnable to verify student in AD: " + result_msg + "}}xx")
                         return None
-                    if tmp.strip() == "":
-                        tmp = student_user
-                student_user = tmp.strip()
-
-                # TODO - Add active directory student username check here instead of SMC
-                # # - Bounce off SMC - verify_ope_account_in_smc
-                # try:
-                #     result = RestClient.verify_ope_account_in_smc(student_user, smc_url, smc_admin_user, smc_admin_password)
-                #     if result is None:
-                #         # Should show errors during the rest call, so none here
-                #         #p("}}rbUnable to validate student against SMC!}}xx")
-                #         # Jump to top of loop and try again
-                #         continue
-                #         #return False # sys.exit(-1)
-                # except Exception as ex:
-                #     p("}}rbError - Unable to verify student in SMC}}xx\n" + str(ex))
-                #     # Jump to top of loop and try again
-                #     continue
-            
-                # If not None - result will be a tuple of information
-                laptop_admin_user, student_full_name, \
-                laptop_network_type, laptop_domain_name, laptop_domain_ou = result
+                    student_name = result_msg
+                else:
+                    p("}}ybNo base_dn set; skipping AD validation.}}xx")
             else:
-                laptop_admin_user = RegistrySettings.get_reg_value(value_name="laptop_admin_user", default="")
-                student_full_name = RegistrySettings.get_reg_value(value_name="student_full_name", default="")
-                laptop_network_type = RegistrySettings.get_reg_value(value_name="laptop_network_type", default="")
-                laptop_domain_name = RegistrySettings.get_reg_value(value_name="laptop_domain_name", default="")
-                laptop_domain_ou = RegistrySettings.get_reg_value(value_name="laptop_domain_ou", default="")
+                p("}}ynPlease enter the student's full name:}}xx ", False)
+                student_name = input().strip()
+                if not student_name:
+                    p("}}rbStudent name cannot be empty.}}xx")
+                    continue
 
-            ad_info = laptop_network_type
-            ad_note = ""
+                import secrets
+                student_password = secrets.token_urlsafe(6)
+                util.store_password(student_user, student_password)
 
-            if laptop_network_type == "Domain Member":
-                ad_info = f"{laptop_domain_name}"
+            ad_info = "Domain Joined" if is_domain_joined else "Standalone"
+            student_text = student_user + " (" + student_name + ")"
 
-            # Are we in a domain?
-            if laptop_network_type == "Standalone":
-                # Config says no domain, make sure that is true.
-                if CredentialProcess.COMPUTER_INFO["cs_part_of_domain"] is True:
-                    p("}}rbSystem is joined to an Active Directory Domain!\n" +
-                        "Please remove this from the domain and try again or adjust laptop configuration in SMC.}}xx")
-                    return None
-            else:
-                if not CredentialProcess.COMPUTER_INFO["cs_part_of_domain"] is True:
-                    # Supposed to be in domain but not!?
-                    p("}}rbSystem needs to be joined to an Active Directory Domain!\n" +
-                        "Please add this machine to the }}yb" + laptop_domain_name + "}}rb domain and try again.}}xx")
-                    return None
-                
-                if CredentialProcess.COMPUTER_INFO["cs_domain"].lower() != laptop_domain_name.lower():
-                    # Part of domain, but name doesn't match - wrong domain?
-                    p("}}rbSystem needs to be joined to an Active Directory Domain!\n" +
-                        "Please add this machine to the }}yb" + laptop_domain_name + "}}rb domain and try again.}}xx")
-                    return None
-                
-                ad_note = "}}rbWARNING - Make sure laptop is in the proper OU (" + laptop_domain_ou + ")}}xx"
-        
-                # add active directory student username check here instead of SMC
-            # Verify that the info is correct
             txt = """
 }}mn======================================================================
 }}mn| }}gbFound Student - Continue?                                          }}mn|
@@ -273,30 +204,24 @@ class CredentialProcess:
 }}mn| }}ynSystem Serial Number:  }}cn<bios_serial_number>}}mn|
 }}mn| }}ynDisk Serial Number:    }}cn<disk_serial_number>}}mn|
 }}mn======================================================================}}xx
-<ad_note>
             """
             col_size = 44
             txt = txt.replace("<mgmt_version>", mgmt_version.ljust(col_size))
             txt = txt.replace("<ad_info>", ad_info.ljust(col_size))
-            student_text = student_user + " (" + student_full_name + ")"
             txt = txt.replace("<student_user>", student_text.ljust(col_size))
-            txt = txt.replace("<bios_serial_number>", 
+            txt = txt.replace("<bios_serial_number>",
                 str(CredentialProcess.COMPUTER_INFO['bios_serial_number']).ljust(col_size))
-            txt = txt.replace("<disk_serial_number>", 
+            txt = txt.replace("<disk_serial_number>",
                 str(CredentialProcess.COMPUTER_INFO['disk_boot_drive_serial_number']).ljust(col_size))
-            txt = txt.replace("<ad_note>", ad_note)
 
-            if not credential_config:
-                p(txt)
-                p("}}ybPress Y to continue: }}xx", False)
-                tmp = input()
-                tmp = tmp.strip().lower()
-                if tmp != "y":
-                    p("}}cnCanceled - trying again....}}xx")
-                    continue
+            p(txt)
+            p("}}ybPress Y to continue: }}xx", False)
+            tmp = input()
+            if tmp.strip().lower() != "y":
+                p("}}cnCanceled - trying again....}}xx")
+                continue
 
-                # Show the warning regarding locking down the boot options
-                p("""
+            p("""
 }}mn======================================================================
 }}mn| }}rb====================       WARNING!!!         ==================== }}mn|
 }}mn| }}xxEnsure that the boot from USB or boot from SD card options in      }}mn|
@@ -304,25 +229,25 @@ class CredentialProcess:
 }}mn| }}xxstrong random password.                                            }}mn|
 }}mn======================================================================}}xx
             """)
-                p("}}ybHave you locked down the BIOS? Press Y to continue: }}xx", False)
-                tmp = input()
-                tmp = tmp.strip().lower()
-                if tmp != "y":
-                    p("}}cnCanceled - trying again....}}xx")
-                    continue
+            p("}}ybHave you locked down the BIOS? Press Y to continue: }}xx", False)
+            tmp = input()
+            if tmp.strip().lower() != "y":
+                p("}}cnCanceled - trying again....}}xx")
+                continue
 
-            # - Bounce off SMC - lms/credential_student.json/??
-            result = None
-            
-            (student_full_name, canvas_url, canvas_access_token,
-            student_password, laptop_admin_password) = result
             loop_running = False
 
-        ret = (student_user, student_full_name, student_password, laptop_admin_user,
-            laptop_admin_password, canvas_access_token, canvas_url,
-            laptop_network_type, laptop_domain_name, laptop_domain_ou)
+        return (student_user, student_name, student_password, is_domain_joined)
 
-        return ret
+    @staticmethod
+    def credential_input_verify_loop():
+        """Gather student info either from registry (credential_config) or interactively."""
+        credential_config = RegistrySettings.get_reg_value(value_name="credential_config", default=False)
+
+        if credential_config:
+            return CredentialProcess._get_student_info_from_registry()
+        else:
+            return CredentialProcess._get_student_info_interactive()
 
     @staticmethod
     def credential_laptop():
@@ -367,42 +292,23 @@ class CredentialProcess:
             p("}}rbERROR - Unable to ensure folders are present and permissions are setup properly!}}xx")
             return False
 
-        if RegistrySettings.is_debug():
-            p("}}rbDEBUG MODE ON - Skipping trust_ope_certs policy}}xx")
-        else:
-            CredentialProcess.trust_ope_certs()
-
         # Disable all student accounts
         UserAccounts.disable_student_accounts()
 
         result = CredentialProcess.credential_input_verify_loop()
         if result is None:
-            # Unable to verify?
             return False
-        (student_user, student_name, student_password,
-            canvas_access_token, canvas_url,
-            laptop_network_type, laptop_domain_name, laptop_domain_ou) = result
-        
-        # - Create local student account
-        if laptop_network_type == "Standalone":
+        (student_user, student_name, student_password, is_domain_joined) = result
+
+        if not is_domain_joined:
             p("}}gnCreating local student windows account...}}xx")
             if not UserAccounts.create_local_student_account(student_user, student_name, student_password):
                 p("}}rbError setting up OPE Student Account}}xx\n " + str(student_user))
                 return False
-
         else:
             p("}}gnRunning as domain laptop, skipping create local student windows account...}}xx")
-            # if not UserAccounts.create_local_student_account(student_user, student_name, student_password):
-            #     p("}}rbError setting up OPE Student Account}}xx\n " + str(student_user))
-            #     return False
-            # TODO - Add student account to allowed users to login
 
-        
-
-        # Store the credential information
-        if not RegistrySettings.store_credential_info(canvas_access_token, canvas_url,
-            student_user, student_name,
-            laptop_network_type, laptop_domain_name, laptop_domain_ou):
+        if not RegistrySettings.store_credential_info(student_user, student_name, is_domain_joined):
             p("}}rbError saving registry info!}}xx")
             return False
         
@@ -414,90 +320,29 @@ class CredentialProcess:
             target_path = "%programdata%\\ope\\Services\\lms\\ope_lms.exe",
             description = "Offline LMS app for Open Prison Education project"
         )
-
-        # NOTE - Machine lock_machine run by credential bat file - student account won't be enabled until then.
-        # p("}}gnLocking machine - applying security settings...}}xx")
-        # if not CredentialProcess.lock_machine():
-        #     p("}}rbERROR - Unable to lock machine after credentail!}}xx")
-        #     return False
         
         return True
 
-    @staticmethod
-    def trust_ope_certs():
-        # Download the CA crt and trust it so we don't get warnings/errors when visiting
-        # the sites
-        p("}}gnGetting OPE Cert file...}}xx", log_level=3)
-        # Get the smc_url - pull the ca.crt file from there
-        smc_url = RegistrySettings.get_reg_value(value_name="smc_url", default="https://smc.corrections.sbctc.edu/")
-        
-        app_path = os.path.dirname(os.path.abspath(__file__))
-        rc_path = os.path.join(app_path, "rc")
-        wget_path = os.path.join(rc_path, "wget.exe")
-        certmgr_path = os.path.join(rc_path, "certmgr.exe")
-        tmp_path = os.path.expandvars("%programdata%\\ope\\tmp")
-        crt_file = os.path.join(tmp_path, "ca.crt")
-        
-        crt_url = smc_url + "/static/certs/ca.crt"
-
-        cmd = "\"" + wget_path + "\" --connect-timeout=6 --tries=3 --no-check-certificate -O \"" + crt_file + "\" " + crt_url
-
-        returncode, output = ProcessManagement.run_cmd(cmd, cwd=tmp_path,
-            require_return_code=0)
-        if returncode == -2:
-            # Error running command?
-            p("}}rbError - unable to pull ca.crt file!}}xx\n" + output)
-            return False
-        p("Ret: " + str(returncode) + " - " + output, log_level=5)
-        
-        # Try to trust the cert
-        cmd = "\"" + certmgr_path + "\" -add \"" + crt_file + "\" -c -s -r localMachine root "
-        returncode, output = ProcessManagement.run_cmd(cmd, cwd=tmp_path,
-            require_return_code=0)
-        if returncode == -2:
-            # Error running command?
-            p("}}rbError - Unable to add ca.crt file into trusted list!}}xx\n" + output)
-            return False
-        p("Ret: " + str(returncode) + " - " + output, log_level=5)
-        
-        return True
-    
     @staticmethod
     def unlock_machine():
-        # Remove security settings from the machine so it can be used by admins to do
-        # maintenance/etc...
         ret = True
 
-        laptop_network_type = CredentialProcess.get_credentialed_network_type()
+        is_domain_joined = CredentialProcess.is_credentialed_domain_joined()
 
-
-        # Make sure mgmt is in the system path
         RegistrySettings.add_mgmt_utility_to_path()
 
-        # Make sure we disable student accounts!
-        # if not UserAccounts.disable_student_accounts():
-        #     p("}}rbUnable to disable student accounts!}}xx")
-        #     return False
-        # Don't disable the account - just remove the OPEStudents group from the logon locally
-        # Doesn't work - gpolicy overwrites it every time it refreshes
-        #UserAccounts.remove_group_from_logon_locally("OPEStudents")
-
-        # Mark machine as not locked
         RegistrySettings.set_machine_locked(False)
 
-        # Log out student accounts!
         if not UserAccounts.log_out_all_students():
             p("}}rbUnable to log out students!}}xx")
             return False
         
-        # Reset group policy
-        if laptop_network_type == "Standalone":
+        if not is_domain_joined:
             GroupPolicy.reset_group_policy_to_default()
         else:
             p("}}ybRunning in Domain Mode, not resetting gpol.}}xx")
 
-        # Reset firewall
-        if laptop_network_type == "Standalone":
+        if not is_domain_joined:
             GroupPolicy.reset_firewall_policy()
         else:
             p("}}ybRunning in Domain Mode, not resetting firewall.}}xx")
@@ -526,101 +371,61 @@ class CredentialProcess:
 
     @staticmethod
     def lock_machine():
-        # Apply secuirty settings and re-enable student account so it can be 
-        # handed back to a student
         ret = True
 
-        # Make sure mgmt is in the system path
         RegistrySettings.add_mgmt_utility_to_path()
 
-        # Get the current credentialed student
         student_user_name = CredentialProcess.get_credentialed_student()
         if student_user_name is None:
             p("}}rbNot Credentiled! - Unable to find credentialed student - not locking machine!}}xx")
             return False
-        
-        # Discontinue use of credentialed admin account
-        # # Get the current admin user name
-        # admin_user_name = CredentialProcess.get_credentialed_admin()
-        # if admin_user_name is None:
-        #     p("}}rbNot Credentiled! - Unable to find credentialed admin account - not locking machine!}}xx")
-        #     return False
-        
-        laptop_network_type = CredentialProcess.get_credentialed_network_type()
 
-        # # Log out the student
-        # if not UserAccounts.log_out_user(student_user_name):
-        #     p("}}rbError - Unable to logout student: " + str(student_user_name) + "}}xx")
-        #     return False
-        # Log out student accounts!
+        is_domain_joined = CredentialProcess.is_credentialed_domain_joined()
+
         if not UserAccounts.log_out_all_students():
             p("}}rbUnable to log out students!}}xx")
             return False
 
-        # Apply firewall rules
-        if laptop_network_type == "Standalone":
+        if not is_domain_joined:
             if not GroupPolicy.apply_firewall_policy():
                 p("}}rbError - Could Not apply firewall policy!\nStudent Account NOT unlocked!}}xx")
                 return False
         else:
             p("}}ybRunning in Domain Mode, not applying firewall policy.}}xx")
 
-        # Apply group policy
         if not GroupPolicy.apply_group_policy():
             p("}}rbError - Could Not apply group policy!\nStudent Account NOT unlocked!}}xx")
             return False
         
-        # Lock down boot options
         if not FolderPermissions.lock_boot_settings():
             p("}}rbError - Could not lock boot settings!\nStudent Account NOT unlocked!}}xx")
             return False
         
-        # Turn off volume shadow copies
         if not FolderPermissions.disable_volume_shadow_copies():
             p("}}rbError - Could not disable VSS settings!\nStudent Account NOT unlocked!}}xx")
             return False
 
-        # Reset registry permissions
         if not RegistrySettings.set_default_ope_registry_permissions(force=True):
             p("}}rbError - Could not reset registry permissions!\nStudent Account NOT unlocked!}}xx")
             return False
 
-        # Reset folder permissions
         if not FolderPermissions.set_default_ope_folder_permissions(force=True):
             p("}}rbError - Could not reset ope folder permissions!\nStudent Account NOT unlocked!}}xx")
             return False
         
-        # Reset student users group memberships
         if not UserAccounts.set_default_groups_for_student(student_user_name):
             p("}}rbError - Could not reset default groups for student!\nStudent Account NOT unlocked!}}xx")
             return False
-        
-        # Discontinue use of credentialed admin account
-        # # Reset admin users group memberships
-        # if not UserAccounts.set_default_groups_for_admin(admin_user_name):
-        #     p("}}rbError - Could not reset default groups for the admin account!\nStudent Account NOT unlocked!}}xx")
-        #     return False
-        
-        # Ensure the OPEService is running
+
         if not CredentialProcess.ensure_opeservice_running():
             p("}}rbError - Verify OPEService is running!\nStudent Account NOT unlocked!}}xx")
             return False
         
-        # Enable student account
-        if laptop_network_type == "Standalone":
+        if not is_domain_joined:
             if not UserAccounts.enable_account(student_user_name):
                 p("}}rbError - Failed to enable student account: " + str(student_user_name) + "}}xx")
                 return False
-        # else:
-        #     # TODO - list student account in allowed users to login
-        #     p("}}ybRunning in Domain Mode, not enabling student account.}}xx")
-        # Use the logon locally attribute to enalble students to login.
-        # Doesn't work - gpolicy overwrites it every time it refreshes
-        # if not UserAccounts.allow_group_to_logon_locally("OPEStudents"):
-        #     p("}}rbError - Unable to enable student account to logon locally! - Student account NOT unlocked!}}xx")
-        #     return False
 
-        # Mark machine as locked
         RegistrySettings.set_machine_locked(True)
 
         return ret
@@ -990,16 +795,8 @@ class CredentialProcess:
     def run_tests():
         p("}}gnRunning Tests...}}xx")
 
-        #UserAccounts.disable_guest_account()
-        #UserAccounts.disable_student_accounts()
-
         p(CredentialProcess.get_mgmt_version())
-        p(CredentialProcess.get_credentialed_network_type())
-        p(CredentialProcess.get_credentialed_domain_name())
-        #RegistrySettings.set_reg_value(value_name="upgrade_started", value=time.time()-9*60)
-        # p("Test")
-        # p(str(RegistrySettings.get_reg_value(value_name="student_user", default=None)))
-        # p(str(RegistrySettings.get_reg_value(app="OPE", value_name="student_user", default=None)))
+        p("is_domain_joined: " + str(CredentialProcess.is_credentialed_domain_joined()))
         pass
 
 

--- a/mgmt/mgmt_CredentialProcess.py
+++ b/mgmt/mgmt_CredentialProcess.py
@@ -79,11 +79,6 @@ class CredentialProcess:
 
         # Create programdata\ope folders and set permissions
         FolderPermissions.set_default_ope_folder_permissions(force=True)
-        
-        # Run the config mgmt utility once
-        if RegistrySettings.get_reg_value(value_name="smc_url", default="<NOT CONFIGURED>") == "<NOT CONFIGURED>":
-            # Never configured - run the config prompt
-            return CredentialProcess.config_mgmt_utility()
 
         return True
         
@@ -171,14 +166,11 @@ class CredentialProcess:
         credential_config = RegistrySettings.get_reg_value(value_name="credential_config", default=False)
         mgmt_version = CredentialProcess.get_mgmt_version()
 
-        smc_url = RegistrySettings.get_reg_value(value_name="smc_url", default="https://smc.corrections.sbctc.edu/")
         canvas_url = ""
         canvas_access_token = ""
         student_user = RegistrySettings.get_reg_value(value_name="student_user", default="")
         student_full_name = ""
         student_password = ""
-        smc_admin_user = RegistrySettings.get_reg_value(value_name="smc_admin_user", default="admin")
-        smc_admin_password = ""
 
         laptop_admin_user = ""
         laptop_admin_password = ""
@@ -202,40 +194,6 @@ class CredentialProcess:
 
             """)
             if not credential_config:
-                # Ask for input (smc server, login, student name, etc...)
-                p("}}ynEnter URL for SMC Server }}cn[enter for " + smc_url + "]:}}xx ", False)
-                tmp = input()
-                tmp = tmp.strip()
-                if tmp.lower() == "quit":
-                    p("}}rnGot QUIT - exiting credential!}}xx")
-                    return None
-                if tmp == "":
-                    tmp = smc_url
-                smc_url = tmp
-                # Make sure url has https or http in it
-                if "https://" not in smc_url.lower() and "http://" not in smc_url.lower():
-                    smc_url = "https://" + smc_url
-
-                p("}}ynPlease enter the ADMIN user name }}cn[enter for " + smc_admin_user + "]:}}xx ", False)
-                tmp = input()
-                tmp = tmp.strip()
-                if tmp.lower() == "quit":
-                    p("}}rnGot QUIT - exiting credential!}}xx")
-                    return None
-                if tmp == "":
-                    tmp = smc_admin_user
-                smc_admin_user = tmp
-
-                p("}}ynPlease enter ADMIN password }}cn[characters will not show]:}}xx", False)
-                tmp = getpass.getpass(" ")
-                if tmp.lower() == "quit":
-                    p("}}rnGot QUIT - exiting credential!}}xx")
-                    return None
-                if tmp == "":
-                    p("}}rbA password is required.}}xx")
-                    continue
-                smc_admin_password = tmp
-
                 tmp = ""
                 last_student_user_prompt = ""
                 while tmp.strip() == "":
@@ -251,41 +209,30 @@ class CredentialProcess:
                         tmp = student_user
                 student_user = tmp.strip()
 
-                # - Bounce off SMC - verify_ope_account_in_smc
-                try:
-                    result = RestClient.verify_ope_account_in_smc(student_user, smc_url, smc_admin_user, smc_admin_password)
-                    if result is None:
-                        # Should show errors during the rest call, so none here
-                        #p("}}rbUnable to validate student against SMC!}}xx")
-                        # Jump to top of loop and try again
-                        continue
-                        #return False # sys.exit(-1)
-                except Exception as ex:
-                    p("}}rbError - Unable to verify student in SMC}}xx\n" + str(ex))
-                    # Jump to top of loop and try again
-                    continue
+                # TODO - Add active directory student username check here instead of SMC
+                # # - Bounce off SMC - verify_ope_account_in_smc
+                # try:
+                #     result = RestClient.verify_ope_account_in_smc(student_user, smc_url, smc_admin_user, smc_admin_password)
+                #     if result is None:
+                #         # Should show errors during the rest call, so none here
+                #         #p("}}rbUnable to validate student against SMC!}}xx")
+                #         # Jump to top of loop and try again
+                #         continue
+                #         #return False # sys.exit(-1)
+                # except Exception as ex:
+                #     p("}}rbError - Unable to verify student in SMC}}xx\n" + str(ex))
+                #     # Jump to top of loop and try again
+                #     continue
             
                 # If not None - result will be a tuple of information
-                laptop_admin_user, student_full_name, smc_version, \
+                laptop_admin_user, student_full_name, \
                 laptop_network_type, laptop_domain_name, laptop_domain_ou = result
             else:
                 laptop_admin_user = RegistrySettings.get_reg_value(value_name="laptop_admin_user", default="")
                 student_full_name = RegistrySettings.get_reg_value(value_name="student_full_name", default="")
-                smc_version = RegistrySettings.get_reg_value(value_name="smc_version", default="")
                 laptop_network_type = RegistrySettings.get_reg_value(value_name="laptop_network_type", default="")
                 laptop_domain_name = RegistrySettings.get_reg_value(value_name="laptop_domain_name", default="")
                 laptop_domain_ou = RegistrySettings.get_reg_value(value_name="laptop_domain_ou", default="")
-                smc_admin_user = RegistrySettings.get_reg_value(value_name="smc_admin_user", default="")
-                smc_admin_password = util.get_smc_password(smc_admin_user)
-                if not smc_admin_password:
-                    p("}}ynSMC Admin password not found in vault, please enter it now.}}xx")
-                    p("}}ynEnter SMC Admin Password }}cn(will not be displayed):}}xx ", False)
-                    smc_admin_password = getpass.getpass(" ")
-                    if smc_admin_password:
-                        util.store_smc_password(smc_admin_user, smc_admin_password)
-                    else:
-                        p("}}rbERROR: SMC Admin password is required.}}xx")
-                        return None
 
             ad_info = laptop_network_type
             ad_note = ""
@@ -314,23 +261,14 @@ class CredentialProcess:
                     return None
                 
                 ad_note = "}}rbWARNING - Make sure laptop is in the proper OU (" + laptop_domain_ou + ")}}xx"
-                
-            # TODO - Need to check laptop name - make sure it is correct
-            #    cs_caption - machin name?
-            #    cs_dns_host_name - full name?
-            # TODO - Need to see if machine is in the right OU
-                           
-            
-                
+        
+                # add active directory student username check here instead of SMC
             # Verify that the info is correct
             txt = """
 }}mn======================================================================
 }}mn| }}gbFound Student - Continue?                                          }}mn|
 }}mn| }}ynCredential Version:    }}cn<mgmt_version>}}mn|
-}}mn| }}ynSMC URL:               }}cn<smc_url>}}mn|
-}}mn| }}ynSMC Version:           }}cn<smc_version>}}mn|
 }}mn| }}ynActive Directory Info: }}cn<ad_info>}}mn|
-}}mn| }}ynLaptop Admin User:     }}cn<admin_user>}}mn|
 }}mn| }}ynStudent Username:      }}cn<student_user>}}mn|
 }}mn| }}ynSystem Serial Number:  }}cn<bios_serial_number>}}mn|
 }}mn| }}ynDisk Serial Number:    }}cn<disk_serial_number>}}mn|
@@ -339,11 +277,7 @@ class CredentialProcess:
             """
             col_size = 44
             txt = txt.replace("<mgmt_version>", mgmt_version.ljust(col_size))
-            txt = txt.replace("<smc_url>", smc_url.ljust(col_size))
-            txt = txt.replace("<smc_version>", smc_version.ljust(col_size))
             txt = txt.replace("<ad_info>", ad_info.ljust(col_size))
-            txt = txt.replace("<admin_user>", laptop_admin_user.ljust(col_size))
-            txt = txt.replace("<admin_pass>", "******".ljust(col_size))
             student_text = student_user + " (" + student_full_name + ")"
             txt = txt.replace("<student_user>", student_text.ljust(col_size))
             txt = txt.replace("<bios_serial_number>", 
@@ -379,34 +313,13 @@ class CredentialProcess:
 
             # - Bounce off SMC - lms/credential_student.json/??
             result = None
-            try:
-                ex_info = dict()
-                ex_info["logged_in_user"] = UserAccounts.get_current_user()
-                ex_info["admin_user"] = laptop_admin_user
-                ex_info["current_student"] = student_user
-                ex_info["mgmt_version"] = mgmt_version
-                
-                ex_info.update(CredentialProcess.COMPUTER_INFO)
-
-                result = RestClient.credential_student_in_smc(
-                    student_user, smc_url, smc_admin_user, smc_admin_password,
-                    dict(ex_info=ex_info))
-                if result is None:
-                    p("}}rbUnable to credential student via SMC!}}xx")
-                    # Jump to top of loop and try again
-                    continue
-                    #return False # sys.exit(-1)
-            except Exception as ex:
-                p("}}rbError - Unable to credential student via SMC}}xx\n" + str(ex))
-                # Jump to top of loop and try again
-                continue
             
             (student_full_name, canvas_url, canvas_access_token,
             student_password, laptop_admin_password) = result
             loop_running = False
 
         ret = (student_user, student_full_name, student_password, laptop_admin_user,
-            laptop_admin_password, canvas_access_token, canvas_url, smc_url,
+            laptop_admin_password, canvas_access_token, canvas_url,
             laptop_network_type, laptop_domain_name, laptop_domain_ou)
 
         return ret
@@ -426,15 +339,6 @@ class CredentialProcess:
         
         # Get computer info
         CredentialProcess.COMPUTER_INFO = Computer.get_machine_info(print_info=False)
-
-        # Are we in a domain?
-        # NOTE - Moved until later - we now can be in a domain if configured.
-        # if CredentialProcess.COMPUTER_INFO["cs_part_of_domain"] is True:
-        #     #p("}}rbSystem is joined to an Active Directory Domain - NOT SUPPORTED!\n" +
-        #     #    "Please remove this from the domain as it might interfere with security settings.}}xx")
-        #     #return False
-        #     p("}}rbSystem is joined to an Active Directory Domain - BETA!!\n" +
-        #       "Only continue if testing.}}xx")
         
         # Are we using a proper edition win 10 or 11? (Home not supported, ed, pro, enterprise ok?)
         # OK - win 10 - pro, ed, enterprise
@@ -475,8 +379,8 @@ class CredentialProcess:
         if result is None:
             # Unable to verify?
             return False
-        (student_user, student_name, student_password, admin_user, admin_password,
-            canvas_access_token, canvas_url, smc_url,
+        (student_user, student_name, student_password,
+            canvas_access_token, canvas_url,
             laptop_network_type, laptop_domain_name, laptop_domain_ou) = result
         
         # - Create local student account
@@ -486,13 +390,6 @@ class CredentialProcess:
                 p("}}rbError setting up OPE Student Account}}xx\n " + str(student_user))
                 return False
 
-            # - Setup admin user
-            p("}}gnCreating local admin windows account...}}xx")
-            try:
-                UserAccounts.create_local_admin_account(admin_user, "OPE Laptop Admin", admin_password)
-            except Exception as ex:
-                p("}}rbError setting up OPE Laptop Admin Account}}xx\n " + str(ex))
-            admin_password = ""
         else:
             p("}}gnRunning as domain laptop, skipping create local student windows account...}}xx")
             # if not UserAccounts.create_local_student_account(student_user, student_name, student_password):
@@ -503,8 +400,8 @@ class CredentialProcess:
         
 
         # Store the credential information
-        if not RegistrySettings.store_credential_info(canvas_access_token, canvas_url, smc_url,
-            student_user, student_name, admin_user,
+        if not RegistrySettings.store_credential_info(canvas_access_token, canvas_url,
+            student_user, student_name,
             laptop_network_type, laptop_domain_name, laptop_domain_ou):
             p("}}rbError saving registry info!}}xx")
             return False
@@ -572,7 +469,6 @@ class CredentialProcess:
         ret = True
 
         laptop_network_type = CredentialProcess.get_credentialed_network_type()
-        laptop_domain_name = CredentialProcess.get_credentialed_domain_name()
 
 
         # Make sure mgmt is in the system path
@@ -651,7 +547,6 @@ class CredentialProcess:
         #     return False
         
         laptop_network_type = CredentialProcess.get_credentialed_network_type()
-        laptop_domain_name = CredentialProcess.get_credentialed_domain_name()
 
         # # Log out the student
         # if not UserAccounts.log_out_user(student_user_name):

--- a/mgmt/mgmt_EventLog.py
+++ b/mgmt/mgmt_EventLog.py
@@ -31,7 +31,7 @@ class EventLog:
         if EventLog._OPE_STATE_LOG_INSTANCE is None:
             # Make the state logger and set it up.
             # NOTE - this is to log to the background of the OPE laptops
-            lf = os.path.join(util.LOG_FOLDER, 'ope-state.log')  #"%programdata%\ope\tmp\log\ope-state.log"
+            lf = os.path.join(util.LOG_FOLDER, "ope-state.log")
             l = logging.getLogger("OPE_STATE")
             l.setLevel(logging.DEBUG)
 

--- a/mgmt/mgmt_FolderPermissions.py
+++ b/mgmt/mgmt_FolderPermissions.py
@@ -553,7 +553,7 @@ class FolderPermissions:
         ret = True
 
         if RegistrySettings.is_debug():
-            p("}}rbDEBUG MODE ON - Skipping lock_boot_settings policy}}xx")
+            p("}}ynDEBUG MODE ON - Skipping lock_boot_settings policy}}xx")
             return True
 
         # Make sure bootim.exe is disabled (the blue screen menu) This will block recovery options
@@ -940,7 +940,7 @@ class FolderPermissions:
         ret = True
 
         if RegistrySettings.is_debug():
-            p("}}rbDEBUG MODE ON - Skipping unlock_boot_settings}}xx")
+            p("}}ynDEBUG MODE ON - Skipping unlock_boot_settings}}xx")
             return True
 
         # Unblock bootim (recovery screen stuff)
@@ -1009,7 +1009,7 @@ class FolderPermissions:
     @staticmethod
     def disable_volume_shadow_copies():
         if RegistrySettings.is_debug():
-            p("}}rbDEBUG MODE ON - Skipping disable volume shadow copies}}xx")
+            p("}}ynDEBUG MODE ON - Skipping disable volume shadow copies}}xx")
             return True
         
         # Make sure SAM isn't readable: https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36934

--- a/mgmt/mgmt_GroupPolicy.py
+++ b/mgmt/mgmt_GroupPolicy.py
@@ -75,7 +75,7 @@ class GroupPolicy:
             value_name="laptop_network_type", default="Standalone", value_type="REG_SZ")
 
         if RegistrySettings.is_debug():
-            p("}}rbDEBUG MODE ON - Skipping apply group policy}}xx")
+            p("}}ynDEBUG MODE ON - Skipping apply group policy}}xx")
             return True
         
         # Lock out browser games
@@ -242,7 +242,7 @@ class GroupPolicy:
     def apply_firewall_policy():
         ret = True
         if RegistrySettings.is_debug():
-            p("}}rbDEBUG MODE ON - Skipping apply firewall policy}}xx")
+            p("}}ynDEBUG MODE ON - Skipping apply firewall policy}}xx")
             return True
 
         if Computer.is_domain_joined() == True:
@@ -275,7 +275,7 @@ class GroupPolicy:
     def reset_firewall_policy():
         ret = True
         if RegistrySettings.is_debug():
-            p("}}rbDEBUG MODE ON - Skipping reset firewall policy}}xx")
+            p("}}ynDEBUG MODE ON - Skipping reset firewall policy}}xx")
             return True
 
         if Computer.is_domain_joined() == True:

--- a/mgmt/mgmt_RegistrySettings.py
+++ b/mgmt/mgmt_RegistrySettings.py
@@ -4,7 +4,6 @@ import sys
 import traceback
 import logging
 import time
-import json
 
 # try:
 #     import _winreg as winreg
@@ -35,15 +34,17 @@ class RegistrySettings:
 
     @staticmethod
     def get_credentialed_student_username():
-        # Get credentialed student username
         student_user = RegistrySettings.get_reg_value(app="OPELMS\\student", value_name="user_name", default="")
-        laptop_network_type = RegistrySettings.get_reg_value(app="OPEService", value_name="laptop_network_type", default="Stand Alone")
-        laptop_domain_name = RegistrySettings.get_reg_value(app="OPEService", value_name="laptop_domain_name", default="osn.local")
+        is_domain_joined = bool(RegistrySettings.get_reg_value(value_name="is_domain_joined", default=0))
 
         ret = student_user
-        if student_user != "" and laptop_network_type == "Domain Member" and laptop_domain_name != "":
-            ret = laptop_domain_name + "\\" + student_user
-        
+        if student_user != "" and is_domain_joined:
+            from mgmt_Computer import Computer
+            cs_info = Computer.get_computer_system_info()
+            domain_name = cs_info.get("cs_domain", "")
+            if domain_name:
+                ret = domain_name + "\\" + student_user
+
         return ret
 
     @staticmethod
@@ -348,73 +349,12 @@ class RegistrySettings:
 
     @staticmethod
     def store_smc_config(config_dict):
-        # Example config_dict
-        # {"smc_version": "v1.9.41", "laptop_network_type": "Domain Member", "laptop_domain_name": "osn.local", "laptop_domain_ou": "laptops.osn.local", "laptop_time_servers": ["time.windows.com", "smc.ed", "osn.local"], "laptop_approved_nics": ["Realtek RTL8139C+ Fast Ethernet NIC==192.168.0.", "ZeroTier Virtual Port==192.168.222."]}
-
-        smc_version = config_dict.get("smc_version", "MISSING")
-        RegistrySettings.set_reg_value(app="", value_name="smc_version", value=smc_version, value_type="REG_SZ")
-
-        laptop_network_type = config_dict.get("laptop_network_type", "Stand Alone")
-        RegistrySettings.set_reg_value(app="OPEService", value_name="laptop_network_type", value=laptop_network_type, value_type="REG_SZ")
-
-        laptop_domain_name = config_dict.get("laptop_domain_name", "osn.local")
-        RegistrySettings.set_reg_value(app="OPEService", value_name="laptop_domain_name", value=laptop_domain_name, value_type="REG_SZ")
-
-        laptop_domain_ou = config_dict.get("laptop_domain_ou", "laptops.osn.local")
-        RegistrySettings.set_reg_value(app="OPEService", value_name="laptop_domain_ou", value=laptop_domain_ou, value_type="REG_SZ")
-
-        try:
-            laptop_time_servers = config_dict.get("laptop_time_servers", [])
-            laptop_time_servers_json = json.dumps(laptop_time_servers)
-            RegistrySettings.set_reg_value(app="OPEService", value_name="laptop_time_servers", value=laptop_time_servers_json)
-        except Exception as ex:
-            p("}}rbError storing time servers: " + str(ex) + "}}xx")
-
-        try:
-            laptop_approved_nics = config_dict.get("laptop_approved_nics", [])
-            # Convert nic==ip format to a array of tuples
-            current_nics_json = RegistrySettings.get_reg_value(app="OPEService", value_name="approved_nics", default="[]")
-            current_nics = json.loads(current_nics_json)
-            
-            for nic in laptop_approved_nics:
-                parts = nic.split("==")
-                #p("}}ynParts: " + str(parts) + "}}xx")
-                if len(parts) == 2:
-                    n = (parts[0], parts[1])
-                    if n not in current_nics:
-                        current_nics.append(n)
-                else:
-                    p("}}rnInvalid NIC format: " + str(nic) + "}}xx")
-                
-            
-            current_nics_json = json.dumps(current_nics)
-            #p("}}gnApproved NICs: " + str(current_nics_json) + "}}xx")
-            RegistrySettings.set_reg_value(app="OPEService", value_name="approved_nics", value=current_nics_json)
-        except Exception as ex:
-            p("}}rbError storing approved nics: " + str(ex) + "}}xx")
-            
+        """Deprecated: SMC configuration is no longer used."""
+        p("}}ynstore_smc_config is deprecated; SMC config storage is no longer used.}}xx")
         return True
 
     @staticmethod
-    def store_credential_info(canvas_access_token, canvas_url, smc_url,
-            student_user, student_name, admin_user,
-            laptop_network_type, laptop_domain_name, laptop_domain_ou):
-        # Store credential info in the proper places
-        RegistrySettings.set_reg_value(app="", value_name="canvas_access_token",
-            value=canvas_access_token, value_type="REG_SZ")
-        RegistrySettings.set_reg_value(app="OPELMS\\student", value_name="canvas_access_token",
-            value=canvas_access_token, value_type="REG_SZ")
-
-        RegistrySettings.set_reg_value(app="", value_name="canvas_url", value=canvas_url,
-            value_type="REG_SZ")
-        RegistrySettings.set_reg_value(app="OPELMS\\student", value_name="canvas_url",
-            value=canvas_url, value_type="REG_SZ")
-
-        RegistrySettings.set_reg_value(app="", value_name="smc_url", value=smc_url,
-            value_type="REG_SZ")
-        RegistrySettings.set_reg_value(app="OPELMS\\student", value_name="smc_url",
-            value=smc_url, value_type="REG_SZ")
-
+    def store_credential_info(student_user, student_name, is_domain_joined):
         RegistrySettings.set_reg_value(app="", value_name="student_user", value=student_user,
             value_type="REG_SZ")
         RegistrySettings.set_reg_value(app="OPELMS\\student", value_name="user_name",
@@ -423,17 +363,8 @@ class RegistrySettings:
         RegistrySettings.set_reg_value(app="", value_name="student_name", value=student_name,
             value_type="REG_SZ")
 
-        RegistrySettings.set_reg_value(app="OPEService", value_name="admin_user", value=admin_user,
-            value_type="REG_SZ")
-        
-        RegistrySettings.set_reg_value(app="OPEService", value_name="laptop_network_type", value=laptop_network_type,
-            value_type="REG_SZ")
-        
-        RegistrySettings.set_reg_value(app="OPEService", value_name="laptop_domain_name", value=laptop_domain_name,
-            value_type="REG_SZ")
-        
-        RegistrySettings.set_reg_value(app="OPEService", value_name="laptop_domain_ou", value=laptop_domain_ou,
-            value_type="REG_SZ")
+        RegistrySettings.set_reg_value(value_name="is_domain_joined",
+            value=1 if is_domain_joined else 0, value_type="REG_DWORD")
 
         return True
 

--- a/mgmt/mgmt_RegistrySettings.py
+++ b/mgmt/mgmt_RegistrySettings.py
@@ -354,7 +354,8 @@ class RegistrySettings:
         return True
 
     @staticmethod
-    def store_credential_info(student_user, student_name, is_domain_joined):
+    def store_credential_info(student_user, student_name, is_domain_joined,
+                              canvas_access_token="", canvas_url=""):
         RegistrySettings.set_reg_value(app="", value_name="student_user", value=student_user,
             value_type="REG_SZ")
         RegistrySettings.set_reg_value(app="OPELMS\\student", value_name="user_name",
@@ -365,6 +366,15 @@ class RegistrySettings:
 
         RegistrySettings.set_reg_value(value_name="is_domain_joined",
             value=1 if is_domain_joined else 0, value_type="REG_DWORD")
+
+        if canvas_access_token:
+            for app_path in ("", "OPELMS\\student"):
+                RegistrySettings.set_reg_value(app=app_path, value_name="canvas_access_token",
+                    value=canvas_access_token, value_type="REG_SZ")
+        if canvas_url:
+            for app_path in ("", "OPELMS\\student"):
+                RegistrySettings.set_reg_value(app=app_path, value_name="canvas_url",
+                    value=canvas_url, value_type="REG_SZ")
 
         return True
 

--- a/mgmt/mgmt_RestClient.py
+++ b/mgmt/mgmt_RestClient.py
@@ -166,7 +166,7 @@ class RestClient:
             if "unable to connect to canvas db" in msg:
                 p("\n}}rbSMC Unable to connect to Canvas DB - make sure canvas app is running and\n" +
                 "the SMC tool is configured to talk to Canvas}}xx")
-                p("}}yn" + str(msg) + "}}xx")
+                p("}}rb" + str(msg) + "}}xx")
                 return None
             if "Unable to find user in canvas:" in  msg:
                 p("\n}}rbInvalid User!}}xx")
@@ -261,7 +261,7 @@ class RestClient:
     def ping_smc(smc_url):
 
         json_response = RestClient.send_rest_call(server=smc_url,
-            api_endpoint="lms/ping.json", timeout=3, log_level=5
+            api_endpoint="lms/ping.json", timeout=5, log_level=5
             )
 
         if json_response is None:

--- a/mgmt/mgmt_RestClient.py
+++ b/mgmt/mgmt_RestClient.py
@@ -275,6 +275,21 @@ class RestClient:
 
         return True
 
+    @staticmethod
+    def validate_smc_credentials(smc_url, admin_user, admin_pw):
+        """Make an authenticated call to SMC to verify admin credentials are accepted.
+        Uses the verify_ope_account endpoint with a dummy user -- any JSON response
+        (even 'Invalid User!') means credentials are valid. A None return from
+        send_rest_call (403 Forbidden / connection error) means they are rejected."""
+        json_response = RestClient.send_rest_call(
+            server=smc_url,
+            api_endpoint="lms/verify_ope_account_in_smc.json/_test",
+            auth_user=admin_user,
+            auth_password=admin_pw,
+            timeout=10,
+        )
+        return json_response is not None
+
 if __name__ == "__main__":
     # Run Tests
     r = RestClient.ping_smc("https://bad_url.com")

--- a/mgmt/mgmt_SystemTime.py
+++ b/mgmt/mgmt_SystemTime.py
@@ -79,15 +79,8 @@ class SystemTime:
             p("}}rnERROR - Unable to update w32tm config!}}xx")
             #errors = True
         
-        p_state("Syncing with NTP servers...", title="NTP Update", kill_logon=False)
-
+        p("}}gnSyncing with NTP servers...}}xx")
         RegistrySettings.set_reg_value(value_name="last_ntp_sync", value=time.time())
-
-
-        # Pull the current time from the SMC server and set it locally.
-        # HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\DateTime\Servers
-        # w32tm /stripchart /computer:smc.ed /dataonly /samples:5
-        # w32tm /query /peers
 
         try:
             # Make sure the time service is running

--- a/mgmt/mgmt_SystemTime.py
+++ b/mgmt/mgmt_SystemTime.py
@@ -82,13 +82,7 @@ class SystemTime:
         p_state("Syncing with NTP servers...", title="NTP Update", kill_logon=False)
 
         RegistrySettings.set_reg_value(value_name="last_ntp_sync", value=time.time())
-        
-        smc_url = RegistrySettings.get_reg_value(value_name="smc_url", default="https://smc.corrections.sbctc.edu")
-        smc_host = smc_url.lower().replace("https://", "").replace("http://", "").replace("/", "")
-        if ":" in smc_host:
-            # port :8000 - remove it
-            pos = smc_host.index(":")
-            smc_host = smc_host[:pos]
+
 
         # Pull the current time from the SMC server and set it locally.
         # HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\DateTime\Servers

--- a/mgmt/mgmt_UserAccounts.py
+++ b/mgmt/mgmt_UserAccounts.py
@@ -560,7 +560,7 @@ class UserAccounts:
             return False
         # Create local student account
         try:
-            p("}}yn\tAdding student account (" + user_name + ")...}}xx")
+            p("}}ynAdding student account (" + user_name + ")...}}xx")
             accounts.User.create(user_name, password)
         # except pywintypes.error as ex:
         except Exception as ex:
@@ -603,7 +603,7 @@ class UserAccounts:
             p("}}rbERROR setting password for " + user_name + "}}xx\n" + str(ex))
 
         # Add student to the students group
-        p("}}yn\tAdding student to students group...}}xx")
+        p("}}ynAdding student to students group...}}xx")
         if not UserAccounts.set_default_groups_for_student(user_name):
             ret = False
         
@@ -615,7 +615,7 @@ class UserAccounts:
         ret = True
                 
         try:
-            p("}}yn\tAdding Admin account (" + user_name + ")...}}xx")
+            p("}}ynAdding Admin account (" + user_name + ")...}}xx")
             accounts.User.create(user_name, password)
             # p("}}yn\t\tDone.}}xx")
         # except pywintypes.error as ex:

--- a/mgmt/mgmt_UserAccounts.py
+++ b/mgmt/mgmt_UserAccounts.py
@@ -558,7 +558,6 @@ class UserAccounts:
         if user_name is None or full_name is None or password is None:
             p("}}rbError - Invalid parameters to create new student user!}}xx", debug_level=1)
             return False
-
         # Create local student account
         try:
             p("}}yn\tAdding student account (" + user_name + ")...}}xx")
@@ -919,7 +918,7 @@ class UserAccounts:
         ret = True
         # Get a list of accounts that are in the students group
         
-        p("}}cb-- Disabling local student accounts in " + str(UserAccounts.STUDENTS_GROUP) + " group...}}xx")
+        p("}}gnDisabling local student accounts in " + str(UserAccounts.STUDENTS_GROUP) + " group...}}xx")
         try:
             grp = accounts.local_group(UserAccounts.STUDENTS_GROUP)
         except winsys.exc.x_not_found as ex:


### PR DESCRIPTION
**PR: Verify students in Active Directory; keep SMC optional for Canvas**

### Summary

- **Student verification:** Stop using SMC REST to prove the student account exists. On domain-joined laptops, validate the student with **Windows ADSI** (LDAP via `pywin32` / ADODB) using **`base_dn`**. On standalone laptops, skip AD validation; use generated passwords and (where applicable) prompted full name.
- **Configuration:** Add required **`is_domain_joined`** (bool) and **`base_dn`** (string). **`smc_url`** and **`smc_admin_username`** are **optional** (must both be set or both empty). When set, the credential flow pings SMC, validates admin credentials, and stores the password with existing **`store_smc_password` / `get_smc_password`** (no rename; `SMC_` vault target prefix unchanged).
- **Mgmt / registry:** Replace **`laptop_network_type` / `laptop_domain_name`** with **`is_domain_joined`**. Remove **`trust_ope_certs`**, SMC-driven config fetch from **`config_mgmt_utility`**, and per-laptop local admin account creation in **`credential_laptop`**. When SMC is configured, **`_fetch_canvas_token_from_smc`** still calls SMC for Canvas tokens only.
- **Reliability / ops:** Harden **`approved_nics`** JSON parsing (empty / invalid JSON no longer crashes). Debug mode skips **`ensure_opeservice_running`**. Child **`mgmt`** runs from **`credential`** can log to **`ope-credential.log`** via **`OPE_MGMT_LOG_FILE`**.
- **Docs / packaging:** Update **`credential/README.md`**, root **`README.md`**, add **`RELEASE_LOG.md`** **26.4.1** notes; **`build_credential.cmd`** copies **`README.md`** into the dist folder.

### Changes

- **`common/util.py`** -- Add **`check_adsi()`** and **`verify_student_account_in_ad()`** for ADSI-based lookup; clarify SMC admin password vault helper messages (names unchanged).
- **`credential/credential.py`** -- Require **`is_domain_joined`** / **`base_dn`**; store them (and optional SMC keys) in registry; replace **`validate_and_store_smc_config()`** with **`validate_and_store_smc_credentials()`**; **`validate_and_store_student_account()`** uses AD when joined; wrap **`json.loads(approved_nics_str)`** in try/except; validate optional SMC keys as a pair; **`run_command()`** supports mgmt log redirection.
- **`credential/credential_config.json`** -- Add **`is_domain_joined`** and **`base_dn`**; keep optional **`smc_url`** / **`smc_admin_username`**.
- **`mgmt/mgmt_CredentialProcess.py`** -- Replace network/domain getters with **`is_credentialed_domain_joined()`**; split input into **`_get_student_info_from_registry()`** and **`_get_student_info_interactive()`**; add **`_fetch_canvas_token_from_smc()`**; simplify **`credential_laptop()`**, **`unlock_machine()`**, **`lock_machine()`**; remove **`trust_ope_certs()`**; debug bypass for **`ensure_opeservice_running()`**.
- **`mgmt/mgmt_RegistrySettings.py`** -- Deprecate **`store_smc_config()`**; simplify **`store_credential_info()`**; **`get_credentialed_student_username()`** uses **`Computer.get_computer_system_info()`** for domain prefix when joined.
- **`mgmt/mgmt.py`** -- Respect **`OPE_MGMT_LOG_FILE`** for logger path; remove **`trust_ope_certs`** command; trim dead commented imports.
- **`mgmt/mgmt_RestClient.py`** -- Add **`validate_smc_credentials()`**; increase SMC ping timeout; minor error output color tweak.
- **`mgmt/mgmt_SystemTime.py`** -- Remove SMC host extraction from NTP sync.
- **`mgmt/mgmt_FolderPermissions.py`**, **`mgmt/mgmt_GroupPolicy.py`**, **`mgmt/mgmt_UserAccounts.py`** -- Minor message / color consistency.
- **`common/color.py`** -- **`init_logger()`** only attaches to an existing app **`EventLog`** (no implicit default mgmt log).
- **`mgmt/mgmt_EventLog.py`** -- Small cleanup for state log path string.
- **`credential/build_credential.cmd`** -- Copy **`README.md`** to dist output.
- **`README.md`**, **`RELEASE_LOG.md`** -- Align top-level docs and release notes with the new behavior.